### PR TITLE
Remove extra gsettings line in configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -149,8 +149,6 @@ AS_IF([test "x$MATECONFTOOL" = "xno"],
       [AC_MSG_ERROR([mateconftool-2 executable not found in your path - should be installed with MateConf])]
 )
 
-GLIB_GSETTINGS
-
 AM_MATECONF_SOURCE_2
 
 AC_ARG_ENABLE([gdict-applet],


### PR DESCRIPTION
This removes the extra GLIB_GSETTINGS in configure.ac. It was present twice in the GNOME version so I thought there was some reason for it. However, it builds fine without the line that is now removed. I also added myself to the wiki page for mate-utils gsettings.
