### PR TITLE
fix libgdict pkg-config file

### DIFF
--- a/mate-dictionary/libgdict/mate-dict.pc.in
+++ b/mate-dictionary/libgdict/mate-dict.pc.in
@@ -7,6 +7,6 @@ Name: gdict-1.0
 Description: MATE Dictionary Protocol client library
 Requires: gtk+-2.0
 Version: @GDICT_VERSION@
-Libs: -L${libdir} -lmate-dict
+Libs: -L${libdir} -llibmatedict
 Cflags: -I${includedir}/mate-dict
 


### PR DESCRIPTION
before

[rave@mother privat_MATE]$ pkg-config --libs mate-dict
-lmate-dict -lgtk-x11-2.0 -lgdk-x11-2.0 -latk-1.0 -lgio-2.0 -lpangoft2-1.0 -lpangocairo-1.0 -lgdk_pixbuf-2.0 -lcairo -lpango-1.0 -lfreetype -lfontconfig -lgobject-2.0 -lglib-2.0

after

[rave@mother privat_MATE]$ pkg-config --libs mate-dict
-llibmatedict -lgtk-x11-2.0 -lgdk-x11-2.0 -latk-1.0 -lgio-2.0 -lpangoft2-1.0 -lpangocairo-1.0 -lgdk_pixbuf-2.0 -lcairo -lpango-1.0 -lfreetype -lfontconfig -lgobject-2.0 -lglib-2.0 
