### PR TITLE
disable masking for area or window screenshots

### DIFF
--- a/mate-screenshot/mate-screenshot.c
+++ b/mate-screenshot/mate-screenshot.c
@@ -809,13 +809,14 @@ static void
 finish_prepare_screenshot (char *initial_uri, GdkWindow *window, GdkRectangle *rectangle)
 {  
   ScreenshotDialog *dialog;
+  gboolean include_mask = (!take_window_shot && !take_area_shot);
 
   /* always disable window border for full-desktop or selected-area screenshots */
   if (!take_window_shot)
-    screenshot = screenshot_get_pixbuf (window, rectangle, include_pointer, FALSE);
+    screenshot = screenshot_get_pixbuf (window, rectangle, include_pointer, FALSE, include_mask);
   else
     {
-      screenshot = screenshot_get_pixbuf (window, rectangle, include_pointer, include_border);
+      screenshot = screenshot_get_pixbuf (window, rectangle, include_pointer, include_border, include_mask);
 
       switch (border_effect[0])
         {

--- a/mate-screenshot/screenshot-utils.c
+++ b/mate-screenshot/screenshot-utils.c
@@ -670,7 +670,8 @@ GdkPixbuf *
 screenshot_get_pixbuf (GdkWindow    *window,
                        GdkRectangle *rectangle,
                        gboolean      include_pointer,
-                       gboolean      include_border)
+                       gboolean      include_border,
+                       gboolean      include_mask)
 {
   GdkWindow *root;
   GdkPixbuf *screenshot;
@@ -738,7 +739,11 @@ screenshot_get_pixbuf (GdkWindow    *window,
                                              x_orig, y_orig, 0, 0,
                                              width, height);
 
-  mask_monitors (screenshot, root);
+  /*
+   * Masking currently only works properly with full-screen shots
+   */
+  if (include_mask)
+      mask_monitors (screenshot, root);
 
 #ifdef HAVE_X11_EXTENSIONS_SHAPE_H
   if (include_border)

--- a/mate-screenshot/screenshot-utils.h
+++ b/mate-screenshot/screenshot-utils.h
@@ -36,7 +36,8 @@ gboolean   screenshot_select_area         (int *px,
 GdkPixbuf *screenshot_get_pixbuf          (GdkWindow *win,
                                            GdkRectangle *rectangle,
                                            gboolean include_pointer,
-                                           gboolean include_border);
+                                           gboolean include_border,
+                                           gboolean include_mask);
 
 void       screenshot_show_error_dialog   (GtkWindow   *parent,
                                            const gchar *message,


### PR DESCRIPTION
Possible fix for https://github.com/mate-desktop/mate-utils/issues/35#issuecomment-25539485
Taken from https://bugzilla.gnome.org/show_bug.cgi?id=587101
