### PR TITLE
screenshot: do not segfault when taking a window picture with no delay

### DIFF
--- a/mate-screenshot/mate-screenshot.c
+++ b/mate-screenshot/mate-screenshot.c
@@ -1368,8 +1368,17 @@ main (int argc, char *argv[])
     }
   else
     {
-      /* start this in an idle anyway and fire up the mainloop */
-      g_idle_add (prepare_screenshot_timeout, NULL);
+      if (interactive_arg)
+        {
+          /* HACK: give time to the dialog to actually disappear.
+           * We don't have any way to tell when the compositor has finished 
+           * re-drawing.
+           */
+          g_timeout_add (200,
+                         prepare_screenshot_timeout, NULL);
+        }
+      else
+        g_idle_add (prepare_screenshot_timeout, NULL);
     }
 
   gtk_main ();


### PR DESCRIPTION
Taken from
https://git.gnome.org/browse/archive/gnome-utils/commit/?id=18a88aa628382382e5aa22bb45752e7bd0c0bfee
