### PR TITLE
Create mate-dictionary.appdata.xml

### DIFF
--- a/mate-dictionary/data/mate-dictionary.appdata.xml
+++ b/mate-dictionary/data/mate-dictionary.appdata.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2014 MATE team <mate-dev@ml.mate-desktop.org> -->
+<component type="desktop">
+ <id>mate-dictionary.desktop</id>
+ <metadata_license>CC0-1.0</metadata_license>
+ <project_license>GPL-2.0+</project_license>
+ <name>Mate Dictionary</name>
+ <summary>A dictionary for MATE Desktop</summary>
+ <description>
+  <p>
+   Mate Dictionary allows you to look up words in on-line dictionaries.
+   It comes preconfigured with a list of Dict servers (RFC 2229), to which
+   you can add your own sources, while you can select specific servers
+   for a specific query.
+  </p>
+ </description>
+ <screenshots>
+  <screenshot type="default">
+   <image width="960" height="540">
+    https://alexpl.fedorapeople.org/AppData/mate-dictionary/screens/mate-dictionary_01.png
+   </image>
+  </screenshot>
+  <screenshot>
+   <image width="688" height="387">
+    https://alexpl.fedorapeople.org/AppData/mate-dictionary/screens/mate-dictionary_02.png
+   </image>
+  </screenshot>
+ </screenshots>
+ <url type="homepage">http://www.mate-desktop.org</url>
+ <updatecontact>mate-dev@ml.mate-desktop.org</updatecontact>
+ <project_group>MATE</project_group>
+</component>


### PR DESCRIPTION
An appdata file for inclusion in the upcoming software centers as per the new freedesktop.org specs.

It should be placed in /usr/share/appdata/ similar to the way .desktop files are placed in /usr/share/applications/, e.g. if you have a "$(datadir)/applications" definition in your makefiles, you need to add a "$(datadir)/appdata" as well.

Please, skim through the file in case I made a mistake and please, include it in the 1.8 branch as well.

Thanks!
