### PR TITLE
Create mate-disk-usage-analyzer.appdata.xml

### DIFF
--- a/baobab/data/mate-disk-usage-analyzer.appdata.xml
+++ b/baobab/data/mate-disk-usage-analyzer.appdata.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2014 MATE team <mate-dev@ml.mate-desktop.org> -->
+<component type="desktop">
+ <id>mate-disk-usage-analyzer.desktop</id>
+ <metadata_license>CC0-1.0</metadata_license>
+ <project_license>GPL-2.0+</project_license>
+ <name>Mate Disk Usage Analyzer</name>
+ <summary>A disk usage analyzing tool for MATE Desktop</summary>
+ <description>
+  <p>
+   As its name implies, Disk Usage Analyzer is a graphical utility that you
+   can use to view and monitor your disk usage and folder structure. It displays
+   summary information in ring or treemap charts.
+  </p>
+  <p>
+   You can perform scans on a file system, your home or any other folder - local
+   or remote. There is also an option to constantly monitor any external changes
+   to the home directory and warn the user if a file is added/removed.
+  </p>
+ </description>
+ <screenshots>
+  <screenshot type="default">
+   <image width="960" height="540">
+    https://alexpl.fedorapeople.org/AppData/mate-disk-usage-analyzer/screens/mate-disk-usage-analyzer_01.png
+   </image>
+  </screenshot>
+  <screenshot>
+   <image width="960" height="540">
+    https://alexpl.fedorapeople.org/AppData/mate-disk-usage-analyzer/screens/mate-disk-usage-analyzer_02.png
+   </image>
+  </screenshot>
+ </screenshots>
+ <url type="homepage">http://www.mate-desktop.org</url>
+ <updatecontact>mate-dev@ml.mate-desktop.org</updatecontact>
+ <project_group>MATE</project_group>
+</component>


### PR DESCRIPTION
An appdata file for inclusion in the upcoming software centers as per the new freedesktop.org specs.

It should be placed in /usr/share/appdata/ similar to the way .desktop files are placed in /usr/share/applications/, e.g. if you have a "$(datadir)/applications" definition in your makefiles, you need to add a "$(datadir)/appdata" as well.

Please, skim through the file in case I made a mistake and please, include it in the 1.8 branch as well.

Thanks!
