### PR TITLE
Create mate-screenshot.appdata.xml

### DIFF
--- a/mate-screenshot/mate-screenshot.appdata.xml
+++ b/mate-screenshot/mate-screenshot.appdata.xml
@@ -13,11 +13,6 @@
    to the system clipboard or save them in Portable Network Graphics (.png)
    image format.
   </p>
-  <p>
-   Pluma is extensible through a plugin system, which currently includes
-   support for spell checking, comparing files, viewing CVS ChangeLogs, and
-   adjusting indentation levels.
-  </p>
  </description>
  <screenshots>
   <screenshot type="default">


### PR DESCRIPTION
An appdata file for inclusion in the upcoming software centers as per the new freedesktop.org specs.

It should be placed in /usr/share/appdata/ similar to the way .desktop files are placed in /usr/share/applications/, e.g. if you have a "$(datadir)/applications" definition in your makefiles, you need to add a "$(datadir)/appdata" as well.

Please, skim through the file in case I made a mistake and please, include it in the 1.8 branch as well.

Thanks!
