### PR TITLE
Create mate-search-tool.appdata.xml

### DIFF
--- a/gsearchtool/mate-search-tool.appdata.xml
+++ b/gsearchtool/mate-search-tool.appdata.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2014 MATE team <mate-dev@ml.mate-desktop.org> -->
+<component type="desktop">
+ <id>mate-search-tool.desktop</id>
+ <metadata_license>CC0-1.0</metadata_license>
+ <project_license>GPL-2.0+</project_license>
+ <name>Mate Search Tool</name>
+ <summary>A file searching tool for MATE Desktop</summary>
+ <description>
+  <p>
+   Mate Search Tool is a simple but powerful utility that allows you to
+   search for files and folders on any mounted file system. Its interface
+   gives you instant access to a wide variety of parameters for each search,
+   such as text contained within a file, ownership, date of modification,
+   file size, folder exclusion, etc..
+  </p>
+ </description>
+ <screenshots>
+  <screenshot type="default">
+   <image width="960" height="540">
+    https://alexpl.fedorapeople.org/AppData/mate-search-tool/screens/mate-search-tool_01.png
+   </image>
+  </screenshot>
+  <screenshot>
+   <image width="960" height="540">
+    https://alexpl.fedorapeople.org/AppData/mate-search-tool/screens/mate-search-tool_02.png
+   </image>
+  </screenshot>
+ </screenshots>
+ <url type="homepage">http://www.mate-desktop.org</url>
+ <updatecontact>mate-dev@ml.mate-desktop.org</updatecontact>
+ <project_group>MATE</project_group>
+</component>


### PR DESCRIPTION
(Should this have been placed in the data folder?)

An appdata file for inclusion in the upcoming software centers as per the new freedesktop.org specs.

It should be placed in /usr/share/appdata/ similar to the way .desktop files are placed in /usr/share/applications/, e.g. if you have a "$(datadir)/applications" definition in your makefiles, you need to add a "$(datadir)/appdata" as well.

Please, skim through the file in case I made a mistake and please, include it in the 1.8 branch as well.

Thanks!
