### PR TITLE
mate-disk-usage-analyzer: fix UI load in GTK+3 build

### DIFF
--- a/baobab/data/baobab-main-window.ui
+++ b/baobab/data/baobab-main-window.ui
@@ -217,7 +217,6 @@
           <object class="GtkToolbar" id="toolbar1">
             <property name="visible">True</property>
             <property name="orientation">GTK_ORIENTATION_HORIZONTAL</property>
-            <property name="tooltips">True</property>
             <property name="show_arrow">False</property>
             <child>
               <object class="GtkToolButton" id="tbscanhome">
@@ -443,7 +442,6 @@
         <child>
           <object class="GtkStatusbar" id="statusbar1">
             <property name="visible">True</property>
-            <property name="has_resize_grip">True</property>
           </object>
           <packing>
             <property name="padding">0</property>


### PR DESCRIPTION
since both properties seem to do nothing in GTK+2 build as well,
I guess it's ok to remove them completely.
