### PR TITLE
mate-screenshot: fix UI load in GTK+3 build

### DIFF
--- a/mate-screenshot/mate-screenshot.ui
+++ b/mate-screenshot/mate-screenshot.ui
@@ -113,8 +113,6 @@
                         <child>
                           <object class="GtkDrawingArea" id="preview_darea">
                             <property name="visible">True</property>
-                            <signal handler="on_preview_expose_event" name="expose_event"/>
-                            <signal handler="on_preview_configure_event" name="configure_event"/>
                           </object>
                         </child>
                       </object>


### PR DESCRIPTION
these two events are set up in the code anyway
