### PR TITLE
[1.8] mate-dictionary: don't free GError more than once

### DIFF
--- a/mate-dictionary/src/gdict-source-dialog.c
+++ b/mate-dictionary/src/gdict-source-dialog.c
@@ -477,7 +477,6 @@ gdict_source_dialog_response_cb (GtkDialog *dialog,
           gdict_show_gerror_dialog (GTK_WINDOW (dialog),
           			    _("There was an error while displaying help"),
           		 	    err);
-          g_error_free (err);
         }
 
       /* we don't want the dialog to close itself */

--- a/mate-dictionary/src/gdict-window.c
+++ b/mate-dictionary/src/gdict-window.c
@@ -1242,7 +1242,6 @@ gdict_window_cmd_help_contents (GtkAction   *action,
       gdict_show_gerror_dialog (GTK_WINDOW (window),
       		                _("There was an error while displaying help"),
       			        err);
-      g_error_free (err);
     }
 }
 


### PR DESCRIPTION
because that error dialog function frees it already

backport of https://github.com/mate-desktop/mate-utils/pull/82 to 1.8 branch