### PR TITLE
[1.8] baobab, gsearchtool: first connect to settings, then read them.

### DIFF
--- a/baobab/src/baobab.c
+++ b/baobab/src/baobab.c
@@ -815,17 +815,17 @@ baobab_setup_excluded_locations (void)
 {
 	gchar **uris;
 
+	g_signal_connect (baobab.prefs_settings,
+			 "changed::" BAOBAB_SETTINGS_EXCLUDED_URIS,
+			  G_CALLBACK (excluded_uris_changed),
+			  NULL);
+
 	uris = g_settings_get_strv (baobab.prefs_settings,
 				    BAOBAB_SETTINGS_EXCLUDED_URIS);
 	baobab_set_excluded_locations (uris);
 	g_strfreev (uris);
 
 	sanity_check_excluded_locations ();
-
-	g_signal_connect (baobab.prefs_settings,
-			 "changed::" BAOBAB_SETTINGS_EXCLUDED_URIS,
-			  G_CALLBACK (excluded_uris_changed),
-			  NULL);
 }
 
 static void
@@ -847,13 +847,13 @@ baobab_setup_monitors (void)
 
 	monitor_volume ();
 
-	enable = g_settings_get_boolean (baobab.prefs_settings,
-					 BAOBAB_SETTINGS_MONITOR_HOME);
-
 	g_signal_connect (baobab.prefs_settings,
 			  "changed::" BAOBAB_SETTINGS_MONITOR_HOME,
 			  G_CALLBACK (baobab_settings_monitor_home_changed),
 			  NULL);
+
+	enable = g_settings_get_boolean (baobab.prefs_settings,
+					 BAOBAB_SETTINGS_MONITOR_HOME);
 
 	monitor_home (enable);
 }

--- a/gsearchtool/gsearchtool.c
+++ b/gsearchtool/gsearchtool.c
@@ -2988,16 +2988,16 @@ gsearchtool_setup_gsettings_notifications (GSearchWindow * gsearch)
 		return;
 	}
 
+	g_signal_connect (gsearch->caja_settings,
+	                  "changed::click-policy",
+	                  G_CALLBACK (single_click_to_activate_key_changed_cb),
+	                  gsearch);
+
 	/* Get value of caja click behavior (single or double click to activate items) */
 	click_to_activate_pref = g_settings_get_string (gsearch->caja_settings, "click-policy");
 
 	gsearch->is_search_results_single_click_to_activate =
 		(strncmp (click_to_activate_pref, "single", 6) == 0) ? TRUE : FALSE;
-
-	g_signal_connect (gsearch->caja_settings,
-	                  "changed::click-policy",
-	                  G_CALLBACK (single_click_to_activate_key_changed_cb),
-	                  gsearch);
 
 	g_free (click_to_activate_pref);
 }


### PR DESCRIPTION
fixes the issue with GLib >= 2.43,
https://git.gnome.org/browse/glib/commit/?id=8ff5668a458344da22d30491e3ce726d861b3619