### PR TITLE
[1.8] mate-screenshot: show the actual error message when UI load fails

### DIFF
--- a/mate-screenshot/screenshot-dialog.c
+++ b/mate-screenshot/screenshot-dialog.c
@@ -211,6 +211,7 @@ screenshot_dialog_new (GdkPixbuf *screenshot,
   gint pos;
   GFile *tmp_file;
   GFile *parent_file;
+  GError *error = NULL;
   guint res;
 
   tmp_file = g_file_new_for_uri (initial_uri);
@@ -223,8 +224,8 @@ screenshot_dialog_new (GdkPixbuf *screenshot,
 
   dialog = g_new0 (ScreenshotDialog, 1);
 
-  dialog-> ui = gtk_builder_new ();
-  res = gtk_builder_add_from_file (dialog->ui, UIDIR "/mate-screenshot.ui", NULL);
+  dialog->ui = gtk_builder_new ();
+  res = gtk_builder_add_from_file (dialog->ui, UIDIR "/mate-screenshot.ui", &error);
   dialog->screenshot = screenshot;
 
   if (res == 0)
@@ -233,10 +234,12 @@ screenshot_dialog_new (GdkPixbuf *screenshot,
       dialog = gtk_message_dialog_new (NULL, 0,
 				       GTK_MESSAGE_ERROR,
 				       GTK_BUTTONS_OK,
-				       _("UI definition file for the screenshot program is missing.\n"
-					 "Please check your installation of mate-utils"));
+				       _("Error loading UI definition file for the screenshot program: \n%s\n\n"
+				         "Please check your installation of mate-utils."), error->message);
       gtk_dialog_run (GTK_DIALOG (dialog));
       gtk_widget_destroy (dialog);
+
+      g_error_free (error);
       exit (1);
     }
 


### PR DESCRIPTION
Backport of https://github.com/mate-desktop/mate-utils/pull/81 to 1.8 branch.