### PR TITLE
fixes for gschema translation

### DIFF
--- a/baobab/data/Makefile.am
+++ b/baobab/data/Makefile.am
@@ -11,15 +11,13 @@ $(baobabapp_in_files): $(baobabapp_in_files:.desktop.in=.desktop.in.in)
 
 @INTLTOOL_DESKTOP_RULE@
 
-gsettingsschema_in_files = org.mate.disk-usage-analyzer.gschema.xml.in
-gsettings_SCHEMAS = $(gsettingsschema_in_files:.xml.in=.xml)
-.PRECIOUS: $(gsettings_SCHEMAS)
 
 @INTLTOOL_XML_RULE@
 appdatadir = $(datadir)/appdata
 appdata_in_files = mate-disk-usage-analyzer.appdata.xml.in
 appdata_DATA = $(appdata_in_files:.xml.in=.xml)
 
+gsettings_SCHEMAS = org.mate.disk-usage-analyzer.gschema.xml
 @GSETTINGS_RULES@
 
 convertdir = $(datadir)/MateConf/gsettings
@@ -30,7 +28,6 @@ man_MANS = mate-disk-usage-analyzer.1
 EXTRA_DIST = \
 	$(ui_DATA) \
 	mate-disk-usage-analyzer.desktop.in.in \
-	$(gsettingsschema_in_files) \
 	$(convert_DATA) \
 	$(appdata_in_files) \
 	$(man_MANS)
@@ -39,4 +36,4 @@ CLEANFILES = \
 	$(baobabapp_in_files) \
 	$(baobabapp_DATA) \
 	$(gsettings_SCHEMAS) \
-	mate-disk-usage-analyzer.appdata.xml
+	$(appdata_DATA)

--- a/baobab/data/org.mate.disk-usage-analyzer.gschema.xml.in
+++ b/baobab/data/org.mate.disk-usage-analyzer.gschema.xml.in
@@ -6,35 +6,35 @@
   <schema gettext-domain="@GETTEXT_PACKAGE@" id="org.mate.disk-usage-analyzer.preferences" path="/org/mate/disk-usage-analyzer/preferences/">
     <key name="monitor-home" type="b">
       <default>false</default>
-      <_summary>Monitor Home</_summary>
-      <_description>Whether any change to the home directory should be monitored.</_description>
+      <summary>Monitor Home</summary>
+      <description>Whether any change to the home directory should be monitored.</description>
     </key>
     <key name="excluded-uris" type="as">
       <default>[]</default>
-      <_summary>Excluded partitions URIs</_summary>
-      <_description>A list of URIs for partitions to be excluded from scanning.</_description>
+      <summary>Excluded partitions URIs</summary>
+      <description>A list of URIs for partitions to be excluded from scanning.</description>
     </key>
   </schema>
   <schema gettext-domain="@GETTEXT_PACKAGE@" id="org.mate.disk-usage-analyzer.ui" path="/org/mate/disk-usage-analyzer/ui/">
     <key name="toolbar-visible" type="b">
       <default>true</default>
-      <_summary>Toolbar is Visible</_summary>
-      <_description>Whether the toolbar should be visible in main window.</_description>
+      <summary>Toolbar is Visible</summary>
+      <description>Whether the toolbar should be visible in main window.</description>
     </key>
     <key name="statusbar-visible" type="b">
       <default>false</default>
-      <_summary>Statusbar is Visible</_summary>
-      <_description>Whether the status bar at the bottom of main window	should be visible.</_description>
+      <summary>Statusbar is Visible</summary>
+      <description>Whether the status bar at the bottom of main window	should be visible.</description>
     </key>
     <key name="subfoldertips-visible" type="b">
       <default>true</default>
-      <_summary>Subfolder tips visible</_summary>
-      <_description>Whether the subfolder tooltips of the selected folder are drawn.</_description>
+      <summary>Subfolder tips visible</summary>
+      <description>Whether the subfolder tooltips of the selected folder are drawn.</description>
     </key>
     <key name="active-chart" type="s">
       <default>'rings'</default>
-      <_summary>Active Chart</_summary>
-      <_description>Which type of chart should be displayed.</_description>
+      <summary>Active Chart</summary>
+      <description>Which type of chart should be displayed.</description>
     </key>
   </schema>
 </schemalist>

--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 MATE_COMMON_INIT
 
-IT_PROG_INTLTOOL([0.40.0])
+IT_PROG_INTLTOOL([0.50.1])
 
 AC_ISC_POSIX
 AC_PROG_CXX
@@ -391,6 +391,7 @@ libeggsmclient/Makefile
 
 baobab/Makefile
 baobab/data/Makefile
+baobab/data/org.mate.disk-usage-analyzer.gschema.xml
 baobab/pixmaps/Makefile
 baobab/pixmaps/24x24/Makefile
 baobab/pixmaps/scalable/Makefile
@@ -399,6 +400,7 @@ baobab/help/Makefile
 
 logview/Makefile
 logview/data/Makefile
+logview/data/org.mate.system-log.gschema.xml
 logview/tests/Makefile
 logview/help/Makefile
 
@@ -412,6 +414,7 @@ mate-dictionary/libgdict/Makefile
 mate-dictionary/libgdict/gdict-version.h
 mate-dictionary/libgdict/mate-dict.pc
 mate-dictionary/data/Makefile
+mate-dictionary/data/org.mate.dictionary.gschema.xml
 mate-dictionary/docs/Makefile
 mate-dictionary/docs/reference/Makefile
 mate-dictionary/docs/reference/gdict/Makefile
@@ -420,6 +423,7 @@ mate-dictionary/help/Makefile
 mate-dictionary/src/Makefile
 
 mate-screenshot/Makefile
+mate-screenshot/org.mate.screenshot.gschema.xml
 ])
 
 AC_OUTPUT

--- a/logview/data/Makefile.am
+++ b/logview/data/Makefile.am
@@ -10,11 +10,9 @@ $(desktop_in_files): $(desktop_in_files:.desktop.in=.desktop.in.in)
 
 man_MANS = mate-system-log.1
 
-gsettingsschema_in_files = org.mate.system-log.gschema.xml.in
-gsettings_SCHEMAS = $(gsettingsschema_in_files:.xml.in=.xml)
-.PRECIOUS: $(gsettings_SCHEMAS)
+gsettings_SCHEMAS = org.mate.system-log.gschema.xml
 
-@INTLTOOL_XML_NOMERGE_RULE@
+@INTLTOOL_XML_RULE@
 
 @GSETTINGS_RULES@
 
@@ -25,8 +23,7 @@ EXTRA_DIST = 			\
 	mate-system-log.desktop.in.in	\
 	$(xml_DATA)		\
 	$(man_MANS)		\
-	$(convert_DATA)	\
-	$(gsettingsschema_in_files)
+	$(convert_DATA)
 
 DISTCLEANFILES =		\
 	$(desktop_DATA)		\

--- a/logview/data/org.mate.system-log.gschema.xml.in
+++ b/logview/data/org.mate.system-log.gschema.xml.in
@@ -2,33 +2,33 @@
   <schema id="org.mate.system-log" path="/org/mate/system-log/">
     <key name="logfile" type="s">
       <default>'/var/log/messages'</default>
-      <_summary>Log file to open up on startup</_summary>
-      <_description>Specifies the log file displayed at startup. The default is either /var/adm/messages or  /var/log/messages, depending on your  operating system.</_description>
+      <summary>Log file to open up on startup</summary>
+      <description>Specifies the log file displayed at startup. The default is either /var/adm/messages or  /var/log/messages, depending on your  operating system.</description>
     </key>
     <key name="fontsize" type="i">
       <default>10</default>
-      <_summary>Size of the font used to display the log</_summary>
-      <_description>Specifies the size of the fixed-width font used to display the log in the main tree view. The default is taken from the default terminal font size.</_description>
+      <summary>Size of the font used to display the log</summary>
+      <description>Specifies the size of the fixed-width font used to display the log in the main tree view. The default is taken from the default terminal font size.</description>
     </key>
     <key name="height" type="i">
       <default>400</default>
-      <_summary>Height of the main window in pixels</_summary>
-      <_description>Specifies the height of the log viewer main window in pixels.</_description>
+      <summary>Height of the main window in pixels</summary>
+      <description>Specifies the height of the log viewer main window in pixels.</description>
     </key>
     <key name="width" type="i">
       <default>600</default>
-      <_summary>Width of the main window in pixels</_summary>
-      <_description>Specifies the width of the log viewer main window in pixels.</_description>
+      <summary>Width of the main window in pixels</summary>
+      <description>Specifies the width of the log viewer main window in pixels.</description>
     </key>
     <key name="logfiles" type="as">
       <default>[]</default>
-      <_summary>Log files to open up on startup</_summary>
-      <_description>Specifies a list of log files to open up at startup. A default list is created by reading /etc/syslog.conf.</_description>
+      <summary>Log files to open up on startup</summary>
+      <description>Specifies a list of log files to open up at startup. A default list is created by reading /etc/syslog.conf.</description>
     </key>
     <key name="filters" type="as">
       <default>[]</default>
-      <_summary>List of saved filters</_summary>
-      <_description>List of saved regexp filters</_description>
+      <summary>List of saved filters</summary>
+      <description>List of saved regexp filters</description>
     </key>
   </schema>
 </schemalist>

--- a/mate-dictionary/data/Makefile.am
+++ b/mate-dictionary/data/Makefile.am
@@ -62,8 +62,7 @@ appdatadir = $(datadir)/appdata
 appdata_in_files = mate-dictionary.appdata.xml.in
 appdata_DATA = $(appdata_in_files:.xml.in=.xml)
 
-gsettingsschema_in_files = org.mate.dictionary.gschema.xml.in
-gsettings_SCHEMAS = $(gsettingsschema_in_files:.xml.in=.xml)
+gsettings_SCHEMAS = org.mate.dictionary.gschema.xml
 @GSETTINGS_RULES@
 
 convertdir = $(datadir)/MateConf/gsettings
@@ -75,7 +74,6 @@ EXTRA_DIST = \
 	mate-dictionary.desktop.in.in \
 	$(dictsource_in_files) \
 	$(man_MANS) \
-	$(gsettingsschema_in_files) \
 	$(appdata_in_files) \
 	$(builder_DATA) \
 	$(ui_DATA) \

--- a/mate-dictionary/data/org.mate.dictionary.gschema.xml.in
+++ b/mate-dictionary/data/org.mate.dictionary.gschema.xml.in
@@ -3,23 +3,23 @@
   <schema id="org.mate.dictionary" path="/org/mate/dictionary/" gettext-domain="@GETTEXT_PACKAGE@">
     <key name="database" type="s">
       <default>'!'</default>
-      <_summary>The default database to use</_summary>
-      <_description>The name of the default individual database or meta-database to use on a dictionary source. An exclamation mark ("!") means that all the databases present in a dictionary source should be searched</_description>
+      <summary>The default database to use</summary>
+      <description>The name of the default individual database or meta-database to use on a dictionary source. An exclamation mark ("!") means that all the databases present in a dictionary source should be searched</description>
     </key>
     <key name="strategy" type="s">
       <default>'exact'</default>
-      <_summary>The default search strategy to use</_summary>
-      <_description>The name of the default search strategy to use on a dictionary source, if available. The default strategy is 'exact', that is match exact words.</_description>
+      <summary>The default search strategy to use</summary>
+      <description>The name of the default search strategy to use on a dictionary source, if available. The default strategy is 'exact', that is match exact words.</description>
     </key>
     <key name="print-font" type="s">
       <default>'Serif 12'</default>
-      <_summary>The font to be used when printing</_summary>
-      <_description>The font to be used when printing a definition.</_description>
+      <summary>The font to be used when printing</summary>
+      <description>The font to be used when printing a definition.</description>
     </key>
     <key name="source-name" type="s">
       <default>'Default'</default>
-      <_summary>The name of the dictionary source used</_summary>
-      <_description>The name of the dictionary source used to retrieve the definitions of words.</_description>
+      <summary>The name of the dictionary source used</summary>
+      <description>The name of the dictionary source used to retrieve the definitions of words.</description>
     </key>
   </schema>
 </schemalist>

--- a/mate-screenshot/Makefile.am
+++ b/mate-screenshot/Makefile.am
@@ -63,30 +63,26 @@ appdatadir = $(datadir)/appdata
 appdata_in_files = mate-screenshot.appdata.xml.in
 appdata_DATA = $(appdata_in_files:.xml.in=.xml)
 
-gsettingsschema_in_files = org.mate.screenshot.gschema.xml.in
-gsettings_SCHEMAS = $(gsettingsschema_in_files:.xml.in=.xml)
-.PRECIOUS: $(gsettings_SCHEMAS)
-
+gsettings_SCHEMAS = org.mate.screenshot.gschema.xml
 @GSETTINGS_RULES@
 
 convertdir = $(datadir)/MateConf/gsettings
 convert_DATA = mate-screenshot.convert
 
 EXTRA_DIST =					\
-	$(gsettingsschema_in_files)		\
 	$(appdata_in_files)			\
-	$(mate_screenshot_in_files)		\
+	$(mate_screenshot_in_files)	\
 	$(man_MANS)				\
 	$(ui_DATA)				\
-	$(convert_DATA)				\
+	$(convert_DATA)			\
 	$(NULL)
 
 CLEANFILES = \
-	$(BUILT_SOURCES)			\
-	$(gsettings_SCHEMAS)			\
-	$(mate_screenshot_DATA)			\
+	$(BUILT_SOURCES)		\
+	$(gsettings_SCHEMAS)	\
+	$(mate_screenshot_DATA)	\
 	$(sys_DATA)				\
-	mate-screenshot.appdata.xml
+	$(appdata_DATA)
 
 dist-hook:
 	cd $(distdir) ; rm -f $(CLEANFILES)

--- a/mate-screenshot/org.mate.screenshot.gschema.xml.in
+++ b/mate-screenshot/org.mate.screenshot.gschema.xml.in
@@ -2,28 +2,28 @@
   <schema id="org.mate.screenshot" path="/org/mate/screenshot/">
     <key name="delay" type="i">
       <default>0</default>
-      <_summary>Screenshot delay</_summary>
-      <_description>The number of seconds to wait before taking the screenshot.</_description>
+      <summary>Screenshot delay</summary>
+      <description>The number of seconds to wait before taking the screenshot.</description>
     </key>
     <key name="last-save-directory" type="s">
       <default>''</default>
-      <_summary>Screenshot directory</_summary>
-      <_description>The directory the last screenshot was saved in.</_description>
+      <summary>Screenshot directory</summary>
+      <description>The directory the last screenshot was saved in.</description>
     </key>
     <key name="include-border" type="b">
       <default>true</default>
-      <_summary>Include Border</_summary>
-      <_description>Include the window manager border along with the screenshot</_description>
+      <summary>Include Border</summary>
+      <description>Include the window manager border along with the screenshot</description>
     </key>
     <key name="include-pointer" type="b">
       <default>true</default>
-      <_summary>Include Pointer</_summary>
-      <_description>Include the pointer in the screenshot</_description>
+      <summary>Include Pointer</summary>
+      <description>Include the pointer in the screenshot</description>
     </key>
     <key name="border-effect" type="s">
       <default>'none'</default>
-      <_summary>Border Effect</_summary>
-      <_description>Effect to add to the outside of a border.  Possible values are "shadow", "none", and "border".</_description>
+      <summary>Border Effect</summary>
+      <description>Effect to add to the outside of a border.  Possible values are "shadow", "none", and "border".</description>
     </key>
   </schema>
 </schemalist>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -3,7 +3,7 @@
 baobab/data/mate-disk-usage-analyzer.desktop.in.in
 [type: gettext/glade]baobab/data/baobab-dialog-scan-props.ui
 [type: gettext/glade]baobab/data/baobab-main-window.ui
-baobab/data/org.mate.disk-usage-analyzer.gschema.xml.in
+[type: gettext/gsettings]baobab/data/org.mate.disk-usage-analyzer.gschema.xml.in
 baobab/data/mate-disk-usage-analyzer.appdata.xml.in
 baobab/src/baobab.c
 baobab/src/baobab-chart.c
@@ -14,10 +14,29 @@ baobab/src/baobab-treeview.c
 baobab/src/baobab-utils.c
 baobab/src/baobab-ringschart.c
 baobab/src/callbacks.c
+gsearchtool/data/mate-search-tool.appdata.xml.in
+gsearchtool/mate-search-tool.desktop.in
+gsearchtool/gsearchtool.c
+gsearchtool/gsearchtool-callbacks.c
+gsearchtool/gsearchtool-support.c
+gsearchtool/org.mate.search-tool.gschema.xml.in
+libeggsmclient/eggdesktopfile.c
+libeggsmclient/eggsmclient.c
+logview/data/mate-system-log.desktop.in.in
+[type: gettext/gsettings]logview/data/org.mate.system-log.gschema.xml.in
+[type: gettext/glade]logview/data/logview-filter.ui
+logview/logview-about.h
+logview/logview-app.c
+logview/logview-filter-manager.c
+logview/logview-findbar.c
+logview/logview-log.c
+logview/logview-loglist.c
+logview/logview-main.c
+logview/logview-window.c
 mate-dictionary/data/default.desktop.in
 mate-dictionary/data/mate-dictionary.desktop.in.in
 mate-dictionary/data/mate-dictionary.appdata.xml.in
-mate-dictionary/data/org.mate.dictionary.gschema.xml.in
+[type: gettext/gsettings]mate-dictionary/data/org.mate.dictionary.gschema.xml.in
 mate-dictionary/data/org.mate.panel.applet.DictionaryAppletFactory.service.in
 mate-dictionary/data/spanish.desktop.in
 mate-dictionary/data/thai.desktop.in
@@ -48,28 +67,9 @@ mate-screenshot/mate-screenshot.c
 mate-screenshot/mate-screenshot.appdata.xml.in
 mate-screenshot/mate-screenshot.desktop.in
 [type: gettext/glade]mate-screenshot/mate-screenshot.ui
-mate-screenshot/org.mate.screenshot.gschema.xml.in
+[type: gettext/gsettings]mate-screenshot/org.mate.screenshot.gschema.xml.in
 mate-screenshot/screenshot-dialog.c
 mate-screenshot/screenshot-save.c
 mate-screenshot/screenshot-shadow.c
 mate-screenshot/screenshot-utils.c
 mate-screenshot/screenshot-xfer.c
-gsearchtool/data/mate-search-tool.appdata.xml.in
-gsearchtool/mate-search-tool.desktop.in
-gsearchtool/gsearchtool.c
-gsearchtool/gsearchtool-callbacks.c
-gsearchtool/gsearchtool-support.c
-gsearchtool/org.mate.search-tool.gschema.xml.in
-libeggsmclient/eggdesktopfile.c
-libeggsmclient/eggsmclient.c
-logview/data/mate-system-log.desktop.in.in
-logview/data/org.mate.system-log.gschema.xml.in
-[type: gettext/glade]logview/data/logview-filter.ui
-logview/logview-about.h
-logview/logview-app.c
-logview/logview-filter-manager.c
-logview/logview-findbar.c
-logview/logview-log.c
-logview/logview-loglist.c
-logview/logview-main.c
-logview/logview-window.c


### PR DESCRIPTION
taken from:
https://github.com/mate-desktop/eom/commit/a2055e1

- bumped required intltool version to 0.50.1
- renamed and corrected gschema xml for proper intltool usage
- sorted lines in po/POTFILES.in (as requested in the header)