### PR TITLE
disk usage analyzer: use correct application name, not "Baobab"

### DIFF
--- a/baobab/src/baobab.c
+++ b/baobab/src/baobab.c
@@ -1242,7 +1242,7 @@ main (int argc, char *argv[])
 	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 	textdomain (GETTEXT_PACKAGE);
 
-	g_set_application_name ("Baobab");
+	g_set_application_name (_("Disk Usage Analyzer"));
 
 	context = g_option_context_new (NULL);
 	g_option_context_set_ignore_unknown_options (context, FALSE);

--- a/baobab/src/callbacks.c
+++ b/baobab/src/callbacks.c
@@ -94,7 +94,6 @@ on_about_activate (GtkMenuItem *menuitem, gpointer user_data)
 	static const gchar copyright[] = "Copyright \xc2\xa9 2005-2010 Fabio Marzocca";
 
 	gtk_show_about_dialog (NULL,
-		"name", _("Disk Usage Analyzer"),
 		"comments", _("A graphical tool to analyze disk usage."),
 		"version", VERSION,
 		"copyright", copyright,


### PR DESCRIPTION
fixes https://github.com/mate-desktop/mate-utils/issues/103

@stefano-k @flexiondotorg 
the name is the same as used before, but the place in code is different, so I guess this will require a sync with transifex for correct l10n