### PR TITLE
logview: Use standard icon name

### DIFF
--- a/logview/data/mate-system-log.desktop.in.in
+++ b/logview/data/mate-system-log.desktop.in.in
@@ -2,7 +2,7 @@
 _Name=Log File Viewer
 _Comment=View or monitor system log files
 Exec=mate-system-log
-Icon=logviewer
+Icon=utilities-system-monitor
 Terminal=false
 Type=Application
 StartupNotify=true

--- a/logview/logview-app.c
+++ b/logview/logview-app.c
@@ -79,7 +79,7 @@ logview_app_set_window (LogviewApp *app)
     retval = TRUE;
   }
 
-  gtk_window_set_default_icon_name ("logviewer");
+  gtk_window_set_default_icon_name ("utilities-system-monitor");
 
   return retval;
 }

--- a/logview/logview-window.c
+++ b/logview/logview-window.c
@@ -768,7 +768,7 @@ logview_about (GtkWidget *widget, GtkWidget *window)
                          "translator_credits", strcmp (logview_about_translator_credits,
                                                        "translator-credits") != 0 ?
                                                logview_about_translator_credits : NULL,
-                         "logo_icon_name", "logviewer",
+                         "logo_icon_name", "utilities-system-monitor",
                          NULL);
   g_free (license_trans);
 


### PR DESCRIPTION
Test case:
1. Install the GTK3 version of mate-utils.
2. Set icon theme to Adwaita.
3. Launch mate-system-log.
4. See the missing application icon.