### PR TITLE
GTK 3.21 dictionary:fix segfault

### DIFF
--- a/mate-dictionary/src/gdict-window.c
+++ b/mate-dictionary/src/gdict-window.c
@@ -1674,7 +1674,7 @@ set_window_default_size (GdictWindow *window)
   if (window->is_maximized)
     gtk_window_maximize (GTK_WINDOW (widget));
 }
-
+#if !GTK_CHECK_VERSION (3, 21, 0)
 static void
 gdict_window_style_set (GtkWidget *widget,
 			GtkStyle  *old_style)
@@ -1685,7 +1685,7 @@ gdict_window_style_set (GtkWidget *widget,
 
   set_window_default_size (GDICT_WINDOW (widget));
 }
-
+#endif
 static void
 gdict_window_handle_notify_position_cb (GtkWidget  *widget,
 					GParamSpec *pspec,
@@ -2107,8 +2107,9 @@ gdict_window_class_init (GdictWindowClass *klass)
   g_object_class_install_properties (gobject_class,
                                      LAST_PROP,
                                      gdict_window_properties);
-
+#if !GTK_CHECK_VERSION (3, 21, 0)
   widget_class->style_set = gdict_window_style_set;
+#endif
   widget_class->size_allocate = gdict_window_size_allocate;
 }
 


### PR DESCRIPTION
Same problem as https://github.com/mate-desktop/caja/issues/540 in Caja: GtkStyle is still used though long deprecated and in this case segfaults. Same fix for now: disable it in Gtk 3.21 and later builds. Dictionary window still follows themes and theme changes in 3.21 without issue,