### PR TITLE
Dictionary: Fix Gtk3.21 segfault

### DIFF
--- a/mate-dictionary/src/gdict-window.c
+++ b/mate-dictionary/src/gdict-window.c
@@ -1628,8 +1628,12 @@ set_window_default_size (GdictWindow *window)
   widget = GTK_WIDGET (window);
 
   /* make sure that the widget is realized */
+  /*Do this implicitly in GTK3.21 or segfault results */
+#if GTK_CHECK_VERSION (3, 21, 0) 
+  gtk_widget_show (widget);
+#else
   gtk_widget_realize (widget);
-  
+#endif  
   /* XXX - the user wants mate-dictionary to resize itself, so
    * we compute the minimum safe geometry needed for displaying
    * the text returned by a dictionary server, which is based


### PR DESCRIPTION
Fix GTK 3.21 segfault caused by issue with calling gtk_widget_realize at this point in the program. Show the widget instead as this does the same thing implicitly and doesn't segfault. Restrict this to GTK 3.21 for now. Mate-dictionary windows haven't resized to fit text all the way back to MATE 1.10 as tested with GTK 3.14, so this whole function needs to either be fixed or removed. My earlier prevented it from being called by disabling a function that used GtkStyle but in this case GtkStyle isn't causing trouble -yet.