### PR TITLE
GTK3 dictionary: Remove style_set class handler

### DIFF
--- a/mate-dictionary/src/gdict-window.c
+++ b/mate-dictionary/src/gdict-window.c
@@ -1611,6 +1611,7 @@ gdict_window_size_allocate (GtkWidget     *widget,
 		    						 allocation);
 }
 
+#if !GTK_CHECK_VERSION (3, 0, 0)
 static void
 set_window_default_size (GdictWindow *window)
 {
@@ -1685,6 +1686,7 @@ gdict_window_style_set (GtkWidget *widget,
 
   set_window_default_size (GDICT_WINDOW (widget));
 }
+#endif
 
 static void
 gdict_window_handle_notify_position_cb (GtkWidget  *widget,
@@ -2108,7 +2110,9 @@ gdict_window_class_init (GdictWindowClass *klass)
                                      LAST_PROP,
                                      gdict_window_properties);
 
+#if !GTK_CHECK_VERSION (3, 0, 0)
   widget_class->style_set = gdict_window_style_set;
+#endif
   widget_class->size_allocate = gdict_window_size_allocate;
 }
 


### PR DESCRIPTION
The ::style-set signal should not be used, and we don't need to resize
on style changes. This eliminates an assertion triggered by the resize
grip.

taken from:
https://git.gnome.org/browse/gnome-dictionary/commit/?id=3313b7c