### PR TITLE
Gtk 3.21 mate-search-tool: fix short entry box

### DIFF
--- a/gsearchtool/src/gsearchtool.c
+++ b/gsearchtool/src/gsearchtool.c
@@ -2767,6 +2767,10 @@ gsearch_app_create (GSearchWindow * gsearch)
 	GtkWidget * label;
 	GtkWidget * button;
 	GtkWidget * container;
+#if GTK_CHECK_VERSION (3, 21, 0)
+	GtkStyleContext *context;
+	GtkCssProvider  *cssProvider;
+#endif
 
 	gsearch->mate_search_tool_settings = g_settings_new ("org.mate.search-tool");
 	gsearch->mate_search_tool_select_settings = g_settings_new ("org.mate.search-tool.select");
@@ -2831,6 +2835,21 @@ gsearch_app_create (GSearchWindow * gsearch)
 	gtk_table_set_row_spacings (GTK_TABLE (gsearch->name_and_folder_table), 6);
 	gtk_table_set_col_spacings (GTK_TABLE (gsearch->name_and_folder_table), 12);
 	gtk_container_add (GTK_CONTAINER (hbox), gsearch->name_and_folder_table);
+
+#if GTK_CHECK_VERSION (3, 21, 0)
+	/*workaround for nonexpanding table probably caused by */
+        /* https://git.gnome.org/browse/gtk+/commit/?id=a72f1c76c87de7a8124a809fe9692194273c563e */
+	context = gtk_widget_get_style_context (GTK_WIDGET (gsearch->name_and_folder_table));
+	gtk_style_context_add_class(context, "mate-search-tool-entry");
+	cssProvider = gtk_css_provider_new ();
+	gtk_css_provider_load_from_data (cssProvider,
+                                     ".mate-search-tool-entry combobox{ \n"                                      
+                                     "min-width: 420px;\n"
+                                      "}",-1, NULL);
+	gtk_style_context_add_provider_for_screen (gdk_screen_get_default(), 
+	GTK_STYLE_PROVIDER(cssProvider),  
+	GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+#endif
 
 	label = gtk_label_new_with_mnemonic (_("_Name contains:"));
 	gtk_label_set_justify (GTK_LABEL (label), GTK_JUSTIFY_LEFT);


### PR DESCRIPTION
Recent changes in GTK 3.21 (probably  https://git.gnome.org/browse/gtk+/commit/?id=a72f1c76c87de7a8124a809fe9692194273c563e ) have caused the "Name Contains" entry and "Look in Folder" button to render far shorter than normal. GNOME has changed the way Gtktable (deprecated) computes expansion  and the table itself does not want to expand to fill the box.

For some reason this does not happen to gnome-search-tool but I was unable to find the difference responsible as the code is very close. Gnome-search-tool still uses Gtktable too as they have not updated this file in something like 5 years.   For mate-search-tool, adding a style class and a cssprovider forces the combobox containing the entry and button back to normal size, pushing the table back out as well. When I tried it on the table in initial tests in my theme it did not work so I put it on the combobox where it did.

Restrict this to GTK 3.21 only to avoid any hassles with older versions.