### PR TITLE
screenshot: don't translate the timestamp in the filename

### DIFF
--- a/mate-screenshot/src/mate-screenshot.c
+++ b/mate-screenshot/src/mate-screenshot.c
@@ -903,10 +903,7 @@ build_uri (AsyncExistenceJob *job)
   GDateTime *d;
 
   d = g_date_time_new_now_local ();
-  /* Translators: This is a strftime format string.
-   * It is used to display the time in 24-hours format (eg, like
-   * in France: 20:10) but using hyphens in place of colons. */
-  timestamp = g_date_time_format (d, _("%Y-%m-%d %H-%M-%S"));
+  timestamp = g_date_time_format (d, "%Y-%m-%d %H-%M-%S");
   g_date_time_unref (d);
 
   if (job->iteration == 0)


### PR DESCRIPTION
See #166. It was a bad idea to translate the timestamp. It had been fixed in gnome-screenshot, now it's time for us to do the same.