### PR TITLE
avoid deprecated gdk_screen_get_width/height and gdk_screen_width/height

### DIFF
--- a/mate-dictionary/src/gdict-aligned-window.c
+++ b/mate-dictionary/src/gdict-aligned-window.c
@@ -157,6 +157,7 @@ gdict_aligned_window_position (GdictAlignedWindow *window)
   GdictAlignedWindowPrivate *priv;
   GtkWidget *align_widget;
   gint our_width, our_height;
+  gint sc_width, sc_height;
   gint entry_x, entry_y, entry_width, entry_height;
   gint x, y;
   GdkGravity gravity = GDK_GRAVITY_NORTH_WEST;
@@ -189,7 +190,10 @@ gdict_aligned_window_position (GdictAlignedWindow *window)
   			 &entry_y);
   gdk_window_get_geometry (gdk_window, NULL, NULL, &entry_width, &entry_height);
 
-  if (entry_x + our_width < gdk_screen_width ())
+  gdk_window_get_geometry (gdk_screen_get_root_window (gdk_screen_get_default()),
+                           NULL, NULL, &sc_width, &sc_height);
+
+  if (entry_x + our_width < sc_width)
     x = entry_x + 1;
   else
     {
@@ -198,7 +202,7 @@ gdict_aligned_window_position (GdictAlignedWindow *window)
       gravity = GDK_GRAVITY_NORTH_EAST;
     }
   
-  if (entry_y + entry_height + our_height < gdk_screen_height ())
+  if (entry_y + entry_height + our_height < sc_height)
     y = entry_y + entry_height - 1;
   else
     {

--- a/mate-screenshot/src/screenshot-utils.c
+++ b/mate-screenshot/src/screenshot-utils.c
@@ -662,8 +662,9 @@ mask_monitors (GdkPixbuf *pixbuf, GdkWindow *root_window)
 
   rect.x = 0;
   rect.y = 0;
-  rect.width = gdk_screen_get_width (screen);
-  rect.height = gdk_screen_get_height (screen);
+
+  gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
+                           &rect.width, &rect.height);
 
   invisible_region = cairo_region_create_rectangle (&rect);
   cairo_region_subtract (invisible_region, region_with_monitors);

--- a/mate-screenshot/src/screenshot-utils.c
+++ b/mate-screenshot/src/screenshot-utils.c
@@ -686,6 +686,10 @@ screenshot_get_pixbuf (GdkWindow    *window,
   GdkPixbuf *screenshot;
   gint x_real_orig, y_real_orig, x_orig, y_orig;
   gint width, real_width, height, real_height;
+  gint sc_width, sc_height;
+
+  gdk_window_get_geometry (gdk_screen_get_root_window (gdk_screen_get_default()),
+                           NULL, NULL, &sc_width, &sc_height);
 
   /* If the screenshot should include the border, we look for the WM window. */
 
@@ -726,11 +730,11 @@ screenshot_get_pixbuf (GdkWindow    *window,
       y_orig = 0;
     }
 
-  if (x_orig + width > gdk_screen_width ())
-    width = gdk_screen_width () - x_orig;
+  if (x_orig + width > sc_width)
+    width = sc_width - x_orig;
 
-  if (y_orig + height > gdk_screen_height ())
-    height = gdk_screen_height () - y_orig;
+  if (y_orig + height > sc_height)
+    height = sc_height - y_orig;
 
   if (rectangle)
     {
@@ -798,11 +802,11 @@ screenshot_get_pixbuf (GdkWindow    *window,
                   rec_height += y_real_orig;
                 }
 
-              if (x_orig + rec_x + rec_width > gdk_screen_width ())
-                rec_width = gdk_screen_width () - x_orig - rec_x;
+              if (x_orig + rec_x + rec_width > sc_width)
+                rec_width = sc_width - x_orig - rec_x;
 
-              if (y_orig + rec_y + rec_height > gdk_screen_height ())
-                rec_height = gdk_screen_height () - y_orig - rec_y;
+              if (y_orig + rec_y + rec_height > sc_height)
+                rec_height = sc_height - y_orig - rec_y;
 
               for (y = rec_y; y < rec_y + rec_height; y++)
                 {


### PR DESCRIPTION
avoid deprecated:

- gdk_screen_get_width/height

- gdk_screen_width/height

