### PR TITLE
WidthOfScreen and HeightOfScreen implementation

### DIFF
--- a/mate-dictionary/src/gdict-aligned-window.c
+++ b/mate-dictionary/src/gdict-aligned-window.c
@@ -29,6 +29,7 @@
 #include <string.h>
 
 #include <gtk/gtk.h>
+#include <gdk/gdkx.h>
 
 #include "gdict-aligned-window.h"
 
@@ -157,7 +158,6 @@ gdict_aligned_window_position (GdictAlignedWindow *window)
   GdictAlignedWindowPrivate *priv;
   GtkWidget *align_widget;
   gint our_width, our_height;
-  gint sc_width, sc_height;
   gint entry_x, entry_y, entry_width, entry_height;
   gint x, y;
   GdkGravity gravity = GDK_GRAVITY_NORTH_WEST;
@@ -190,10 +190,7 @@ gdict_aligned_window_position (GdictAlignedWindow *window)
   			 &entry_y);
   gdk_window_get_geometry (gdk_window, NULL, NULL, &entry_width, &entry_height);
 
-  gdk_window_get_geometry (gdk_screen_get_root_window (gdk_screen_get_default()),
-                           NULL, NULL, &sc_width, &sc_height);
-
-  if (entry_x + our_width < sc_width)
+  if (entry_x + our_width < WidthOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())))
     x = entry_x + 1;
   else
     {
@@ -202,7 +199,7 @@ gdict_aligned_window_position (GdictAlignedWindow *window)
       gravity = GDK_GRAVITY_NORTH_EAST;
     }
   
-  if (entry_y + entry_height + our_height < sc_height)
+  if (entry_y + entry_height + our_height < HeightOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())))
     y = entry_y + entry_height - 1;
   else
     {

--- a/mate-screenshot/src/screenshot-utils.c
+++ b/mate-screenshot/src/screenshot-utils.c
@@ -22,6 +22,7 @@
 #include "screenshot-utils.h"
 
 #include <X11/Xatom.h>
+#include <gdk/gdkx.h>
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
 #include <glib.h>
@@ -634,9 +635,8 @@ mask_monitors (GdkPixbuf *pixbuf, GdkWindow *root_window)
 
   rect.x = 0;
   rect.y = 0;
-
-  gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-                           &rect.width, &rect.height);
+  rect.width = WidthOfScreen (gdk_x11_screen_get_xscreen (screen));
+  rect.height = HeightOfScreen (gdk_x11_screen_get_xscreen (screen));
 
   invisible_region = cairo_region_create_rectangle (&rect);
   cairo_region_subtract (invisible_region, region_with_monitors);
@@ -658,10 +658,6 @@ screenshot_get_pixbuf (GdkWindow    *window,
   GdkPixbuf *screenshot;
   gint x_real_orig, y_real_orig, x_orig, y_orig;
   gint width, real_width, height, real_height;
-  gint sc_width, sc_height;
-
-  gdk_window_get_geometry (gdk_screen_get_root_window (gdk_screen_get_default()),
-                           NULL, NULL, &sc_width, &sc_height);
 
   /* If the screenshot should include the border, we look for the WM window. */
 
@@ -702,11 +698,11 @@ screenshot_get_pixbuf (GdkWindow    *window,
       y_orig = 0;
     }
 
-  if (x_orig + width > sc_width)
-    width = sc_width - x_orig;
+  if (x_orig + width > WidthOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())))
+    width = WidthOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())) - x_orig;
 
-  if (y_orig + height > sc_height)
-    height = sc_height - y_orig;
+  if (y_orig + height > HeightOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())))
+    height = HeightOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())) - y_orig;
 
   if (rectangle)
     {
@@ -774,11 +770,11 @@ screenshot_get_pixbuf (GdkWindow    *window,
                   rec_height += y_real_orig;
                 }
 
-              if (x_orig + rec_x + rec_width > sc_width)
-                rec_width = sc_width - x_orig - rec_x;
+              if (x_orig + rec_x + rec_width > WidthOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())))
+                rec_width = WidthOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())) - x_orig - rec_x;
 
-              if (y_orig + rec_y + rec_height > sc_height)
-                rec_height = sc_height - y_orig - rec_y;
+              if (y_orig + rec_y + rec_height > HeightOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())))
+                rec_height = HeightOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())) - y_orig - rec_y;
 
               for (y = rec_y; y < rec_y + rec_height; y++)
                 {


### PR DESCRIPTION
This commit reverts:

https://github.com/mate-desktop/mate-utils/commit/b210e404823cb5b1fa5b74d700fa3f89c2ea71a2
https://github.com/mate-desktop/mate-utils/commit/c0b5081bf32ee22094e15c5d76a8ac8e5806e4a5

And it applies an alternative to fix the deprecated functions:

gkd_screen_width
gdk_screen_height

gdk_screen_get_width
gdk_screen_get_height