### PR TITLE
mate-screenshot: added New button

### DIFF
--- a/mate-screenshot/data/mate-screenshot.ui
+++ b/mate-screenshot/data/mate-screenshot.ui
@@ -37,6 +37,17 @@
               </packing>
             </child>
             <child>
+              <object class="GtkButton" id="new_button">
+                <property name="visible">False</property>
+                <property name="can_default">True</property>
+                <property name="can_focus">True</property>
+                <property name="label">gtk-new</property>
+                <property name="use_stock">True</property>
+                <property name="relief">GTK_RELIEF_NORMAL</property>
+                <property name="focus_on_click">True</property>
+              </object>
+            </child>
+            <child>
               <object class="GtkButton" id="copy_button">
                 <property name="label" translatable="yes">C_opy to Clipboard</property>
                 <property name="visible">True</property>
@@ -220,6 +231,7 @@
       <action-widget response="1">copy_button</action-widget>
       <action-widget response="-6">cancel_button</action-widget>
       <action-widget response="-5">ok_button</action-widget>
+      <action-widget response="22">new_button</action-widget>
     </action-widgets>
   </object>
 </interface>

--- a/mate-screenshot/src/mate-screenshot.c
+++ b/mate-screenshot/src/mate-screenshot.c
@@ -119,6 +119,8 @@ static GtkWidget *effect_label = NULL;
 static GtkWidget *effects_vbox = NULL;
 static GtkWidget *delay_hbox = NULL;
 
+void loop_dialog_screenshot ();
+
 static void
 display_help (GtkWindow *parent)
 {
@@ -1261,7 +1263,7 @@ screenshooter_init_stock_icons (void)
 }
 
 void
-loop_dialog_screenshot (void)
+loop_dialog_screenshot ()
 {
   /* interactive mode overrides everything */
   if (interactive_arg)
@@ -1277,7 +1279,7 @@ loop_dialog_screenshot (void)
         {
         case GTK_RESPONSE_DELETE_EVENT:
         case GTK_RESPONSE_CANCEL:
-          return EXIT_SUCCESS;
+          return;
         case GTK_RESPONSE_OK:
           break;
         default:

--- a/mate-screenshot/src/screenshot-dialog.h
+++ b/mate-screenshot/src/screenshot-dialog.h
@@ -26,6 +26,7 @@ typedef struct ScreenshotDialog ScreenshotDialog;
 
 /* Keep in sync with the value defined in the UI file */
 #define SCREENSHOT_RESPONSE_COPY 1
+#define SCREENSHOT_RESPONSE_NEW 22
 
 ScreenshotDialog *screenshot_dialog_new          (GdkPixbuf        *screenshot,
 						  char             *initial_uri,


### PR DESCRIPTION
I need to capture numerous screenshots or reselect the area. For this I needed to be constantly opening and closing the mate-screenshot application. I made this improvement to increase my productivity.
Any questions I am available.
Best regards

![image](https://user-images.githubusercontent.com/1813123/34819990-7c036f6c-f6a6-11e7-8674-f65316593936.png)
