### PR TITLE
Baobab help: Terminal command updated to 'mate-disk-usage-analyzer'

### DIFF
--- a/baobab/help/C/index.docbook
+++ b/baobab/help/C/index.docbook
@@ -165,7 +165,7 @@
 
 <para>If you want to start <application>&app;</application> from a terminal window, just type:</para> 
   
-<para><command>baobab &lt;full_path_to_a_directory&gt;</command>, then press <keycap>Return</keycap>.</para>  
+<para><command>mate-disk-usage-analyzer &lt;full_path_to_a_directory&gt;</command>, then press <keycap>Return</keycap>.</para>  
 <para></para> 
 	<para>If launched from Mate menu, <application>&app;</application> starts and remains in a stand-by state, waiting for user action.</para> 
     <para>When you start <application>&app;</application> from the Mate Menu, the following window is displayed.</para>

--- a/baobab/help/ca/ca.po
+++ b/baobab/help/ca/ca.po
@@ -314,10 +314,10 @@ msgstr ""
 
 #: C/baobab.xml:143(para)
 msgid ""
-"<command>baobab &lt;full_path_to_a_directory&gt;</command>, then press "
+"<command>mate-disk-usage-analyzer &lt;full_path_to_a_directory&gt;</command>, then press "
 "<keycap>Return</keycap>."
 msgstr ""
-"<command>baobab &lt;camí_complet_a_una_carpeta&gt;</command>, i després "
+"<command>mate-disk-usage-analyzer &lt;camí_complet_a_una_carpeta&gt;</command>, i després "
 "premeu la tecla <keycap>Retorn</keycap>."
 
 #: C/baobab.xml:145(para)

--- a/baobab/help/cs/cs.po
+++ b/baobab/help/cs/cs.po
@@ -313,10 +313,10 @@ msgstr ""
 
 #: C/baobab.xml:143(para)
 msgid ""
-"<command>baobab &lt;full_path_to_a_directory&gt;</command>, then press "
+"<command>mate-disk-usage-analyzer &lt;full_path_to_a_directory&gt;</command>, then press "
 "<keycap>Return</keycap>."
 msgstr ""
-"<command>baobab &lt;celá_cesta_k_adresáři&gt;</command> a stiskněte "
+"<command>mate-disk-usage-analyzer &lt;celá_cesta_k_adresáři&gt;</command> a stiskněte "
 "<keycap>Enter</keycap>."
 
 #: C/baobab.xml:145(para)

--- a/baobab/help/da/da.po
+++ b/baobab/help/da/da.po
@@ -202,10 +202,10 @@ msgstr ""
 
 #: ../C/baobab.xml:143(para)
 msgid ""
-"<command>baobab &lt;full_path_to_a_directory&gt;</command>, then press "
+"<command>mate-disk-usage-analyzer &lt;full_path_to_a_directory&gt;</command>, then press "
 "<keycap>Return</keycap>."
 msgstr ""
-"<command>baobab %lt;fuld_sti_til_en_mappe%gt;</command>, og tryk så "
+"<command>mate-disk-usage-analyzer %lt;fuld_sti_til_en_mappe%gt;</command>, og tryk så "
 "<keycap>Enter</keycap>."
 
 #: ../C/baobab.xml:145(para)

--- a/baobab/help/de/de.po
+++ b/baobab/help/de/de.po
@@ -311,10 +311,10 @@ msgstr ""
 
 #: C/baobab.xml:143(para)
 msgid ""
-"<command>baobab &lt;full_path_to_a_directory&gt;</command>, then press "
+"<command>mate-disk-usage-analyzer &lt;full_path_to_a_directory&gt;</command>, then press "
 "<keycap>Return</keycap>."
 msgstr ""
-"<command>baobab &lt;kompletter_Pfad_zum_Ordner&gt;</command>, dann drücken "
+"<command>mate-disk-usage-analyzer &lt;kompletter_Pfad_zum_Ordner&gt;</command>, dann drücken "
 "Sie die <keycap>Eingabetaste</keycap>."
 
 #: C/baobab.xml:145(para)

--- a/baobab/help/el/el.po
+++ b/baobab/help/el/el.po
@@ -186,8 +186,8 @@ msgid "If you want to start <application>Disk Usage Analyzer</application> from 
 msgstr "Αν θέλετε να ξεκινήσετε την <application>Ανάλυση χρήσης δίσκου</application> από ένα παράθυρο τερματικού, απλά πληκτρολογήστε:"
 
 #: C/baobab.xml:143(para)
-msgid "<command>baobab &lt;full_path_to_a_directory&gt;</command>, then press <keycap>Return</keycap>."
-msgstr "<command>baobab &lt;πλήρης_διαδρομή_προς_έναν_κατάλογο&gt;</command>, και μετά πατήστε <keycap>Return</keycap>."
+msgid "<command>mate-disk-usage-analyzer &lt;full_path_to_a_directory&gt;</command>, then press <keycap>Return</keycap>."
+msgstr "<command>mate-disk-usage-analyzer &lt;πλήρης_διαδρομή_προς_έναν_κατάλογο&gt;</command>, και μετά πατήστε <keycap>Return</keycap>."
 
 #: C/baobab.xml:145(para)
 msgid "If launched from Mate menu, <application>Disk Usage Analyzer</application> starts and remains in a stand-by state, waiting for user action."

--- a/baobab/help/en_GB/en_GB.po
+++ b/baobab/help/en_GB/en_GB.po
@@ -309,10 +309,10 @@ msgstr ""
 
 #: ../C/baobab.xml:143(para)
 msgid ""
-"<command>baobab &lt;full_path_to_a_directory&gt;</command>, then press "
+"<command>mate-disk-usage-analyzer &lt;full_path_to_a_directory&gt;</command>, then press "
 "<keycap>Return</keycap>."
 msgstr ""
-"<command>baobab &lt;full_path_to_a_directory&gt;</command>, then press "
+"<command>mate-disk-usage-analyzer &lt;full_path_to_a_directory&gt;</command>, then press "
 "<keycap>Return</keycap>."
 
 #: ../C/baobab.xml:145(para)

--- a/baobab/help/es/es.po
+++ b/baobab/help/es/es.po
@@ -312,10 +312,10 @@ msgstr ""
 
 #: C/baobab.xml:143(para)
 msgid ""
-"<command>baobab &lt;full_path_to_a_directory&gt;</command>, then press "
+"<command>mate-disk-usage-analyzer &lt;full_path_to_a_directory&gt;</command>, then press "
 "<keycap>Return</keycap>."
 msgstr ""
-"<command>baobab &lt;ruta_completa_al_directorio&gt;</command>, entonces "
+"<command>mate-disk-usage-analyzer &lt;ruta_completa_al_directorio&gt;</command>, entonces "
 "pulse <keycap>Intro</keycap>."
 
 #: C/baobab.xml:145(para)

--- a/baobab/help/eu/eu.po
+++ b/baobab/help/eu/eu.po
@@ -164,8 +164,8 @@ msgid "If you want to start <application>Disk Usage Analyzer</application> from 
 msgstr "<application>Disko-erabileraren analizatzailea</application> terminal-leiho batetik abiarazi nahi baduzu, idatzi hau:"
 
 #: C/baobab.xml:143(para)
-msgid "<command>baobab &lt;full_path_to_a_directory&gt;</command>, then press <keycap>Return</keycap>."
-msgstr "<command>baobab &lt;direktorioaren bide-izen osoa&gt;</command>, eta sakatu <keycap>Sartu</keycap>."
+msgid "<command>mate-disk-usage-analyzer &lt;full_path_to_a_directory&gt;</command>, then press <keycap>Return</keycap>."
+msgstr "<command>mate-disk-usage-analyzer &lt;direktorioaren bide-izen osoa&gt;</command>, eta sakatu <keycap>Sartu</keycap>."
 
 #: C/baobab.xml:145(para)
 msgid "If launched from Mate menu, <application>Disk Usage Analyzer</application> starts and remains in a stand-by state, waiting for user action."

--- a/baobab/help/fi/fi.po
+++ b/baobab/help/fi/fi.po
@@ -214,8 +214,8 @@ msgid "If you want to start <application>Disk Usage Analyzer</application> from 
 msgstr "Jos tahdot käynnistää <application>Levynkäytön analysoinnin</application> pääteikkunasta, kirjoitat vain:"
 
 #: C/baobab.xml:143(para)
-msgid "<command>baobab &lt;full_path_to_a_directory&gt;</command>, then press <keycap>Return</keycap>."
-msgstr "<command>baobab &lt;koko_polku_hakemistoon&gt;</command> ja painat <keycap>Enter</keycap> -näppäintä."
+msgid "<command>mate-disk-usage-analyzer &lt;full_path_to_a_directory&gt;</command>, then press <keycap>Return</keycap>."
+msgstr "<command>mate-disk-usage-analyzer &lt;koko_polku_hakemistoon&gt;</command> ja painat <keycap>Enter</keycap> -näppäintä."
 
 #: C/baobab.xml:145(para)
 msgid "If launched from Mate menu, <application>Disk Usage Analyzer</application> starts and remains in a stand-by state, waiting for user action."

--- a/baobab/help/fr/fr.po
+++ b/baobab/help/fr/fr.po
@@ -323,10 +323,10 @@ msgstr ""
 
 #: ../C/baobab.xml:143(para)
 msgid ""
-"<command>baobab &lt;full_path_to_a_directory&gt;</command>, then press "
+"<command>mate-disk-usage-analyzer &lt;full_path_to_a_directory&gt;</command>, then press "
 "<keycap>Return</keycap>."
 msgstr ""
-"<command>baobab &lt;chemin complet d'un dossier&gt;</command>, puis appuyez "
+"<command>mate-disk-usage-analyzer &lt;chemin complet d'un dossier&gt;</command>, puis appuyez "
 "sur <keycap>Entrée</keycap>."
 
 #: ../C/baobab.xml:145(para)

--- a/baobab/help/it/it.po
+++ b/baobab/help/it/it.po
@@ -323,10 +323,10 @@ msgstr ""
 
 #: C/baobab.xml:143(para)
 msgid ""
-"<command>baobab &lt;full_path_to_a_directory&gt;</command>, then press "
+"<command>mate-disk-usage-analyzer &lt;full_path_to_a_directory&gt;</command>, then press "
 "<keycap>Return</keycap>."
 msgstr ""
-"<command>baobab &lt;percorso_completo_di_una_directory&gt;</command>, poi "
+"<command>mate-disk-usage-analyzer &lt;percorso_completo_di_una_directory&gt;</command>, poi "
 "premere <keycap>Invio</keycap>."
 
 #: C/baobab.xml:145(para)

--- a/baobab/help/oc/oc.po
+++ b/baobab/help/oc/oc.po
@@ -263,7 +263,7 @@ msgstr ""
 
 #: C/baobab.xml:143(para)
 msgid ""
-"<command>baobab &lt;full_path_to_a_directory&gt;</command>, then press "
+"<command>mate-disk-usage-analyzer &lt;full_path_to_a_directory&gt;</command>, then press "
 "<keycap>Return</keycap>."
 msgstr ""
 

--- a/baobab/help/pl/pl.po
+++ b/baobab/help/pl/pl.po
@@ -187,8 +187,8 @@ msgid "If you want to start <application>Disk Usage Analyzer</application> from 
 msgstr "Aby uruchomić <application>Analizator wykorzystania dysku</application> z okna terminala, należy wpisać:"
 
 #: C/baobab.xml:143(para)
-msgid "<command>baobab &lt;full_path_to_a_directory&gt;</command>, then press <keycap>Return</keycap>."
-msgstr "<command>baobab &lt;pełna_ścieżka_do_katalogu&gt;</command>, i nacisnąć klawisz <keycap>Enter</keycap>."
+msgid "<command>mate-disk-usage-analyzer &lt;full_path_to_a_directory&gt;</command>, then press <keycap>Return</keycap>."
+msgstr "<command>mate-disk-usage-analyzer &lt;pełna_ścieżka_do_katalogu&gt;</command>, i nacisnąć klawisz <keycap>Enter</keycap>."
 
 #: C/baobab.xml:145(para)
 msgid "If launched from Mate menu, <application>Disk Usage Analyzer</application> starts and remains in a stand-by state, waiting for user action."

--- a/baobab/help/ru/ru.po
+++ b/baobab/help/ru/ru.po
@@ -308,10 +308,10 @@ msgstr ""
 
 #: C/baobab.xml:143(para)
 msgid ""
-"<command>baobab &lt;full_path_to_a_directory&gt;</command>, then press "
+"<command>mate-disk-usage-analyzer &lt;full_path_to_a_directory&gt;</command>, then press "
 "<keycap>Return</keycap>."
 msgstr ""
-"<command>baobab ‹полный_путь_к_папке›</command>, затем нажмите <keycap>Enter</"
+"<command>mate-disk-usage-analyzer ‹полный_путь_к_папке›</command>, затем нажмите <keycap>Enter</"
 "keycap>."
 
 #: C/baobab.xml:145(para)

--- a/baobab/help/sv/sv.po
+++ b/baobab/help/sv/sv.po
@@ -178,8 +178,8 @@ msgid "If you want to start <application>Disk Usage Analyzer</application> from 
 msgstr "Om du vill starta <application>Diskanvändningsanalysator</application> från ett terminalfönster, skriv helt enkelt:"
 
 #: C/baobab.xml:143(para)
-msgid "<command>baobab &lt;full_path_to_a_directory&gt;</command>, then press <keycap>Return</keycap>."
-msgstr "<command>baobab &lt;fullständig_sökväg_till_en_katalog&gt;</command>, tryck sedan på <keycap>Return</keycap>."
+msgid "<command>mate-disk-usage-analyzer &lt;full_path_to_a_directory&gt;</command>, then press <keycap>Return</keycap>."
+msgstr "<command>mate-disk-usage-analyzer &lt;fullständig_sökväg_till_en_katalog&gt;</command>, tryck sedan på <keycap>Return</keycap>."
 
 #: C/baobab.xml:145(para)
 msgid "If launched from Mate menu, <application>Disk Usage Analyzer</application> starts and remains in a stand-by state, waiting for user action."

--- a/baobab/help/uk/uk.po
+++ b/baobab/help/uk/uk.po
@@ -313,10 +313,10 @@ msgstr ""
 
 #: C/baobab.xml:143(para)
 msgid ""
-"<command>baobab &lt;full_path_to_a_directory&gt;</command>, then press "
+"<command>mate-disk-usage-analyzer &lt;full_path_to_a_directory&gt;</command>, then press "
 "<keycap>Return</keycap>."
 msgstr ""
-"<command>baobab &lt;повний_шлях_до_каталогу&gt;</command>, потім натисніть "
+"<command>mate-disk-usage-analyzer &lt;повний_шлях_до_каталогу&gt;</command>, потім натисніть "
 "<keycap>Enter</keycap>."
 
 #: C/baobab.xml:145(para)

--- a/baobab/help/zh_CN/zh_CN.po
+++ b/baobab/help/zh_CN/zh_CN.po
@@ -291,10 +291,10 @@ msgstr ""
 
 #: C/baobab.xml:143(para)
 msgid ""
-"<command>baobab &lt;full_path_to_a_directory&gt;</command>, then press "
+"<command>mate-disk-usage-analyzer &lt;full_path_to_a_directory&gt;</command>, then press "
 "<keycap>Return</keycap>."
 msgstr ""
-"<command>baobab &lt;full_path_to_a_directory&gt;</command>，然后按一下 "
+"<command>mate-disk-usage-analyzer &lt;full_path_to_a_directory&gt;</command>，然后按一下 "
 "<keycap>回车键</keycap>。"
 
 #: C/baobab.xml:145(para)

--- a/baobab/help/zh_HK/zh_HK.po
+++ b/baobab/help/zh_HK/zh_HK.po
@@ -247,9 +247,9 @@ msgstr "如果你想要從終端機視窗開啟 <application>磁碟用量分析�
 
 #: C/baobab.xml:146(para)
 msgid ""
-"<command>baobab &lt;full_path_to_a_directory&gt;</command>, then press "
+"<command>mate-disk-usage-analyzer &lt;full_path_to_a_directory&gt;</command>, then press "
 "<keycap>Return</keycap>."
-msgstr "<command>baobab &lt;full_path_to_a_directory&gt;</command>，然後按下 <keycap>Return</keycap>。"
+msgstr "<command>mate-disk-usage-analyzer &lt;full_path_to_a_directory&gt;</command>，然後按下 <keycap>Return</keycap>。"
 
 #: C/baobab.xml:148(para)
 msgid ""

--- a/baobab/help/zh_TW/zh_TW.po
+++ b/baobab/help/zh_TW/zh_TW.po
@@ -289,10 +289,10 @@ msgstr ""
 
 #: C/baobab.xml:146(para)
 msgid ""
-"<command>baobab &lt;full_path_to_a_directory&gt;</command>, then press "
+"<command>mate-disk-usage-analyzer &lt;full_path_to_a_directory&gt;</command>, then press "
 "<keycap>Return</keycap>."
 msgstr ""
-"<command>baobab &lt;full_path_to_a_directory&gt;</command>，然後按下 "
+"<command>mate-disk-usage-analyzer &lt;full_path_to_a_directory&gt;</command>，然後按下 "
 "<keycap>Return</keycap>。"
 
 #: C/baobab.xml:148(para)


### PR DESCRIPTION
In the help files, the terminal command to run mate-disk-usage-analyzer was described as 'baobab' (Help section 'Getting started'). This pull request changes that 'mate-disk-usage-analyzer' in all language files.

I hope I didn't misunderstand the help system, but since it's kind of a template issue, I did edit both msgIDs and msgSTRs, as well as index.docbook...