### PR TITLE
mate-dictionary: Fix memory leak

### DIFF
--- a/mate-dictionary/src/gdict-pref-dialog.c
+++ b/mate-dictionary/src/gdict-pref-dialog.c
@@ -459,19 +459,22 @@ static void
 font_button_font_set_cb (GtkWidget       *font_button,
 			 GdictPrefDialog *dialog)
 {
-  const char *font;
+  gchar *font;
   
   font = gtk_font_chooser_get_font (GTK_FONT_CHOOSER (font_button));
-  if (!font || font[0] == '\0')
-    return;
 
-  if (g_strcmp0 (dialog->print_font, font) == 0)
-    return;
-  
+  if (!font || font[0] == '\0' || g_strcmp0 (dialog->print_font, font) == 0)
+    {
+      g_free (font);
+      return;
+    }
+
   g_free (dialog->print_font);
   dialog->print_font = g_strdup (font);
 
   g_settings_set_string (dialog->settings, GDICT_SETTINGS_PRINT_FONT_KEY, dialog->print_font);
+
+  g_free (font);
 }
 
 static void


### PR DESCRIPTION
seems since the commit https://github.com/mate-desktop/mate-utils/commit/c0800eff5739c3891375d5c4d1db62720fd877cd we have a memory leak

according to the documentation, `gtk_font_chooser_get_font` needs to be freed

https://developer.gnome.org/gtk3/stable/GtkFontChooser.html#gtk-font-chooser-get-font