### PR TITLE
help - bump docbook 4.5

### DIFF
--- a/baobab/help/C/index.docbook
+++ b/baobab/help/C/index.docbook
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN" 
-"http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [ 
+<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" 
+"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [ 
   <!ENTITY legal SYSTEM "legal.xml">
   <!ENTITY appversion "1.10">
   <!ENTITY manrevision "1.10">

--- a/gsearchtool/help/C/index.docbook
+++ b/gsearchtool/help/C/index.docbook
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN" 
-"http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
+<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" 
+"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
   <!ENTITY legal SYSTEM "legal.xml">
   <!ENTITY appversion "1.10">
   <!ENTITY manrevision "1.10">

--- a/logview/help/C/index.docbook
+++ b/logview/help/C/index.docbook
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN" 
-"http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [ 
+<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" 
+"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [ 
   <!ENTITY legal SYSTEM "legal.xml">
   <!ENTITY appversion "1.10">
   <!ENTITY manrevision "1.10">

--- a/mate-dictionary/docs/reference/gdict/gdict-docs.sgml
+++ b/mate-dictionary/docs/reference/gdict/gdict-docs.sgml
@@ -1,6 +1,6 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-    "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
+<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+    "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
 
 <!ENTITY version SYSTEM "version.xml">
 ]>

--- a/mate-dictionary/help/C/index.docbook
+++ b/mate-dictionary/help/C/index.docbook
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN" "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
+<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
 <!ENTITY app "Dictionary">
 <!ENTITY applet "Dictionary Applet">
 <!ENTITY appversion "1.10">


### PR DESCRIPTION
fix validate errors:
$ find . -name "index.docbook" -exec yelp-check validate {} \;

validity error : Element othercredit content does not follow the DTD, expecting (honorific | firstname | surname | lineage | othername | affiliation | authorblurb | contrib)+, got (personname email )