### PR TITLE
mate-disk-usage-analyzer: Memory leak

### DIFF
--- a/baobab/src/baobab.c
+++ b/baobab/src/baobab.c
@@ -1193,6 +1193,8 @@ initialize_charts (void)
 		gtk_combo_box_set_active (GTK_COMBO_BOX (baobab.chart_type_combo), 0);
 	}
 
+	g_free (saved_chart);
+
 	check_drop_targets (FALSE);
 }
 


### PR DESCRIPTION
To detect the memory leak using valgrind:

export CFLAGS="-Og -g -fno-omit-frame-pointer -fPIE -pie"
export CXXFLAGS="-Og -g -fno-omit-frame-pointer -fPIE -pie"
./autogen.sh --prefix=/usr
make clean
make
sudo make install
valgrind --tool=memcheck --undef-value-errors=no --leak-check=full --log-file="report.txt" /usr/bin/mate-disk-usage-analyzer

report.txt content:

==16061== 6 bytes in 1 blocks are definitely lost in loss record 174 of 14,390
==16061==    at 0x483880B: malloc (vg_replace_malloc.c:309)
==16061==    by 0x56B10D7: g_malloc (gmem.c:99)
==16061==    by 0x56CAAEE: g_strdup (gstrfuncs.c:363)
==16061==    by 0x56E3743: g_variant_dup_string (gvariant.c:1533)
==16061==    by 0x5509DE6: g_settings_get_string (gsettings.c:1795)
==16061==    by 0x115664: initialize_charts (baobab.c:1185)
==16061==    by 0x11640C: main (baobab.c:1307)