### PR TITLE
Change url project's website

### DIFF
--- a/baobab/data/mate-disk-usage-analyzer.appdata.xml.in
+++ b/baobab/data/mate-disk-usage-analyzer.appdata.xml.in
@@ -30,7 +30,7 @@
    </image>
   </screenshot>
  </screenshots>
- <url type="homepage">http://www.mate-desktop.org</url>
+ <url type="homepage">https://mate-desktop.org</url>
  <updatecontact>mate-dev@ml.mate-desktop.org</updatecontact>
  <project_group>MATE</project_group>
 </component>

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ m4_define([mate_utils_version], [mate_utils_major.mate_utils_minor.mate_utils_mi
 
 AC_INIT([mate-utils],
         [mate_utils_version],
-        [http://www.mate-desktop.org/])
+        [https://mate-desktop.org/])
 
 AC_CONFIG_MACRO_DIR([m4])
 

--- a/gsearchtool/data/mate-search-tool.appdata.xml.in
+++ b/gsearchtool/data/mate-search-tool.appdata.xml.in
@@ -27,7 +27,7 @@
    </image>
   </screenshot>
  </screenshots>
- <url type="homepage">http://www.mate-desktop.org</url>
+ <url type="homepage">https://mate-desktop.org</url>
  <updatecontact>mate-dev@ml.mate-desktop.org</updatecontact>
  <project_group>MATE</project_group>
 </component>

--- a/mate-dictionary/data/mate-dictionary.appdata.xml.in
+++ b/mate-dictionary/data/mate-dictionary.appdata.xml.in
@@ -26,7 +26,7 @@
    </image>
   </screenshot>
  </screenshots>
- <url type="homepage">http://www.mate-desktop.org</url>
+ <url type="homepage">https://mate-desktop.org</url>
  <updatecontact>mate-dev@ml.mate-desktop.org</updatecontact>
  <project_group>MATE</project_group>
 </component>

--- a/mate-screenshot/data/mate-screenshot.appdata.xml.in
+++ b/mate-screenshot/data/mate-screenshot.appdata.xml.in
@@ -21,7 +21,7 @@
    </image>
   </screenshot>
  </screenshots>
- <url type="homepage">http://www.mate-desktop.org</url>
+ <url type="homepage">https://mate-desktop.org</url>
  <updatecontact>mate-dev@ml.mate-desktop.org</updatecontact>
  <project_group>MATE</project_group>
 </component>


### PR DESCRIPTION
Now the official web site is https://mate-desktop.org/.