### PR TITLE
mate-disk-usage-analyzer: Remove blank space before right parenthesis

### DIFF
--- a/baobab/src/baobab.c
+++ b/baobab/src/baobab.c
@@ -179,7 +179,7 @@ update_scan_label (void)
 		available = g_format_size (baobab.fs.avail);
 
 	/* Translators: these are labels for disk space */
-	markup = g_markup_printf_escaped  ("<small>%s <b>%s</b> (%s %s %s %s )</small>",
+	markup = g_markup_printf_escaped  ("<small>%s <b>%s</b> (%s %s %s %s)</small>",
 					   _("Total filesystem capacity:"), total,
 					   _("used:"), used,
 					   _("available:"), available);


### PR DESCRIPTION
Before "... (used: 9.3 GB available: 51.5 GB )"

![VirtualBox_Fedora 9_21_07_2019_19_09_15](https://user-images.githubusercontent.com/10171411/61594478-b17e8080-abec-11e9-923d-bea2f92b063c.png)


After "... (used: 9.4 GB available: 51.4 GB)"

![VirtualBox_Fedora 9_21_07_2019_19_18_40](https://user-images.githubusercontent.com/10171411/61594479-b80cf800-abec-11e9-8d4e-92a5cc5fa215.png)
