### PR TITLE
avoid redundant redeclarations

### DIFF
--- a/baobab/src/baobab-chart.c
+++ b/baobab/src/baobab-chart.c
@@ -102,8 +102,6 @@ const BaobabChartColor baobab_chart_tango_colors[] = {{0.94, 0.16, 0.16}, /* tan
                                                       {0.91, 0.73, 0.43}, /* tango: e9b96e */
                                                       {0.99, 0.68, 0.25}}; /* tango: fcaf3e */
 
-static void baobab_chart_class_init (BaobabChartClass *class);
-static void baobab_chart_init (BaobabChart *object);
 static void baobab_chart_realize (GtkWidget *widget);
 static void baobab_chart_dispose (GObject *object);
 static void baobab_chart_size_allocate (GtkWidget *widget,

--- a/baobab/src/baobab-remote-connect-dialog.c
+++ b/baobab/src/baobab-remote-connect-dialog.c
@@ -54,9 +54,6 @@ struct _BaobabRemoteConnectDialogDetails {
 	GtkWidget *user_entry;
 };
 
-static void  baobab_remote_connect_dialog_class_init       (BaobabRemoteConnectDialogClass *class);
-static void  baobab_remote_connect_dialog_init             (BaobabRemoteConnectDialog      *dialog);
-
 G_DEFINE_TYPE(BaobabRemoteConnectDialog, baobab_remote_connect_dialog, GTK_TYPE_DIALOG)
 
 #define RESPONSE_CONNECT GTK_RESPONSE_OK

--- a/baobab/src/baobab-ringschart.c
+++ b/baobab/src/baobab-ringschart.c
@@ -74,8 +74,6 @@ struct _BaobabRingschartPrivate
 
 G_DEFINE_TYPE_WITH_PRIVATE (BaobabRingschart, baobab_ringschart, BAOBAB_CHART_TYPE);
 
-static void baobab_ringschart_class_init (BaobabRingschartClass *class);
-static void baobab_ringschart_init (BaobabRingschart *object);
 static void baobab_ringschart_draw_sector (cairo_t *cr,
                                            gdouble center_x, gdouble center_y,
                                            gdouble radius, gdouble thickness,

--- a/baobab/src/baobab-treemap.c
+++ b/baobab/src/baobab-treemap.c
@@ -53,8 +53,6 @@ struct _BaobabTreemapPrivate
 
 G_DEFINE_TYPE_WITH_PRIVATE (BaobabTreemap, baobab_treemap, BAOBAB_CHART_TYPE);
 
-static void baobab_treemap_class_init (BaobabTreemapClass *class);
-static void baobab_treemap_init (BaobabTreemap *object);
 static void baobab_treemap_draw_rectangle (GtkWidget *chart,
                                            cairo_t *cr,
                                            gdouble x, gdouble y, gdouble width, gdouble height,

--- a/gsearchtool/src/gsearchtool-callbacks.c
+++ b/gsearchtool/src/gsearchtool-callbacks.c
@@ -47,10 +47,6 @@
 
 #define SILENT_WINDOW_OPEN_LIMIT 5
 
-#ifdef HAVE_GETPGID
-extern pid_t getpgid (pid_t);
-#endif
-
 gboolean row_selected_by_button_press_event;
 
 static void


### PR DESCRIPTION
Fixes the warnings:
```
baobab-ringschart.c:77:13: warning: redundant redeclaration of 'baobab_ringschart_class_init' [-Wredundant-decls]
baobab-ringschart.c:78:13: warning: redundant redeclaration of 'baobab_ringschart_init' [-Wredundant-decls]
baobab-remote-connect-dialog.c:60:42: warning: redundant redeclaration of 'baobab_remote_connect_dialog_init' [-Wredundant-decls]
baobab-remote-connect-dialog.c:60:42: warning: redundant redeclaration of 'baobab_remote_connect_dialog_class_init' [-Wredundant-decls]
baobab-chart.c:105:13: warning: redundant redeclaration of 'baobab_chart_class_init' [-Wredundant-decls]
baobab-chart.c:106:13: warning: redundant redeclaration of 'baobab_chart_init' [-Wredundant-decls]
baobab-treemap.c:56:13: warning: redundant redeclaration of 'baobab_treemap_class_init' [-Wredundant-decls]
baobab-treemap.c:57:13: warning: redundant redeclaration of 'baobab_treemap_init' [-Wredundant-decls]
gsearchtool-callbacks.c:51:14: warning: redundant redeclaration of 'getpgid' [-Wredundant-decls]
```