### PR TITLE
Remove warnings: function declaration isn’t a prototype

### DIFF
--- a/logview/src/logview-app.c
+++ b/logview/src/logview-app.c
@@ -94,7 +94,7 @@ typedef struct {
 
 /* adapted from sysklogd sources */
 static GSList*
-parse_syslog ()
+parse_syslog (void)
 {
   char cbuf[BUFSIZ];
   char *cline, *p;

--- a/mate-screenshot/src/mate-screenshot.c
+++ b/mate-screenshot/src/mate-screenshot.c
@@ -120,7 +120,7 @@ static GtkWidget *effect_label = NULL;
 static GtkWidget *effects_vbox = NULL;
 static GtkWidget *delay_hbox = NULL;
 
-void loop_dialog_screenshot ();
+void loop_dialog_screenshot (void);
 
 static void
 display_help (GtkWindow *parent)
@@ -1248,7 +1248,7 @@ screenshooter_init_stock_icons (void)
 }
 
 void
-loop_dialog_screenshot ()
+loop_dialog_screenshot (void)
 {
   /* interactive mode overrides everything */
   if (interactive_arg)


### PR DESCRIPTION
```
mate-screenshot.c:123:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  123 | void loop_dialog_screenshot ();
      | ^~~~

mate-screenshot.c:1251:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
 1251 | loop_dialog_screenshot ()
      | ^~~~~~~~~~~~~~~~~~~~~~

logview-app.c:97:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
   97 | parse_syslog ()
      | ^~~~~~~~~~~~
```