### PR TITLE
baobab: Remove unused variable ‘uri_list’

### DIFF
--- a/baobab/src/baobab.c
+++ b/baobab/src/baobab.c
@@ -733,7 +733,6 @@ store_excluded_locations (void)
 {
 	GSList *l;
 	GPtrArray *uris;
-	GSList *uri_list = NULL;
 
 	uris = g_ptr_array_new ();
 


### PR DESCRIPTION
```
baobab.c:736:10: warning: unused variable ‘uri_list’ [-Wunused-variable]
  736 |  GSList *uri_list = NULL;
      |          ^~~~~~~~
```