### PR TITLE
mate-dictionary: remove unused function 'gdict_window_set_statusbar_visible'

### DIFF
--- a/mate-dictionary/src/gdict-window.c
+++ b/mate-dictionary/src/gdict-window.c
@@ -253,30 +253,6 @@ gdict_window_set_sidebar_visible (GdictWindow *window,
 }
 
 static void
-gdict_window_set_statusbar_visible (GdictWindow *window,
-				    gboolean     is_visible)
-{
-  g_assert (GDICT_IS_WINDOW (window));
-
-  is_visible = !!is_visible;
-
-  if (is_visible != window->statusbar_visible)
-    {
-      GtkAction *action;
-
-      window->statusbar_visible = is_visible;
-
-      if (window->statusbar_visible)
-	gtk_widget_show (window->status);
-      else
-	gtk_widget_hide (window->status);
-
-      action = gtk_action_group_get_action (window->action_group, "ViewStatusbar");
-      gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action), window->statusbar_visible);
-    }
-}
-
-static void
 gdict_window_definition_cb (GdictContext    *context,
 			    GdictDefinition *definition,
 			    GdictWindow     *window)


### PR DESCRIPTION
```
./autogen.sh --enable-compile-warnings=maximum --prefix=/usr && make &> make.log
```
Removed warning:
```
gdict-window.c:256:1: warning: ‘gdict_window_set_statusbar_visible’ defined but not used [-Wunused-function]
  256 | gdict_window_set_statusbar_visible (GdictWindow *window,
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```