### PR TITLE
Remove bad-function-cast warnings

### DIFF
--- a/gsearchtool/src/gsearchtool-support.c
+++ b/gsearchtool/src/gsearchtool-support.c
@@ -848,23 +848,27 @@ gsearchtool_get_thumbnail_image (const gchar * thumbnail)
 			gfloat scale_factor_y = 1.0;
 			gint scale_x;
 			gint scale_y;
+			gint width;
+			gint height;
 
 			thumbnail_pixbuf = gdk_pixbuf_new_from_file (thumbnail, NULL);
 			gsearchtool_thumbnail_frame_image (&thumbnail_pixbuf);
 
-			if (gdk_pixbuf_get_width (thumbnail_pixbuf) > ICON_SIZE) {
-				scale_factor_x = (gfloat) ICON_SIZE / (gfloat) gdk_pixbuf_get_width (thumbnail_pixbuf);
+			width = gdk_pixbuf_get_width (thumbnail_pixbuf);
+			if (width > ICON_SIZE) {
+				scale_factor_x = (gfloat) ICON_SIZE / (gfloat) width;
 			}
-			if (gdk_pixbuf_get_height (thumbnail_pixbuf) > ICON_SIZE) {
-				scale_factor_y = (gfloat) ICON_SIZE / (gfloat) gdk_pixbuf_get_height (thumbnail_pixbuf);
+			height = gdk_pixbuf_get_height (thumbnail_pixbuf);
+			if (height > ICON_SIZE) {
+				scale_factor_y = (gfloat) ICON_SIZE / (gfloat) height;
 			}
 
-			if (gdk_pixbuf_get_width (thumbnail_pixbuf) > gdk_pixbuf_get_height (thumbnail_pixbuf)) {
+			if (width > height) {
 				scale_x = ICON_SIZE;
-				scale_y = (gint) (gdk_pixbuf_get_height (thumbnail_pixbuf) * scale_factor_x);
+				scale_y = (gint) (height * scale_factor_x);
 			}
 			else {
-				scale_x = (gint) (gdk_pixbuf_get_width (thumbnail_pixbuf) * scale_factor_y);
+				scale_x = (gint) (width * scale_factor_y);
 				scale_y = ICON_SIZE;
 			}
 

--- a/gsearchtool/src/gsearchtool.c
+++ b/gsearchtool/src/gsearchtool.c
@@ -905,13 +905,14 @@ add_file_to_search_results (const gchar * file,
 	utf8_relative_dir_name = g_filename_display_name (relative_dir_name);
 
 	gtk_list_store_append (GTK_LIST_STORE (store), iter);
+	goffset file_size = g_file_info_get_size (file_info);
 	gtk_list_store_set (GTK_LIST_STORE (store), iter,
 			    COLUMN_ICON, pixbuf,
 			    COLUMN_NAME, utf8_base_name,
 			    COLUMN_RELATIVE_PATH, utf8_relative_dir_name,
 			    COLUMN_LOCALE_FILE, file,
 			    COLUMN_READABLE_SIZE, readable_size,
-			    COLUMN_SIZE, (-1) * (gdouble) g_file_info_get_size(file_info),
+			    COLUMN_SIZE, (-1) * (gdouble) file_size,
 			    COLUMN_TYPE, (description != NULL) ? description : g_strdup (g_file_info_get_content_type (file_info)),
 			    COLUMN_READABLE_DATE, readable_date,
 			    COLUMN_DATE, (-1) * (gdouble) time_val.tv_sec,

--- a/mate-screenshot/src/screenshot-dialog.c
+++ b/mate-screenshot/src/screenshot-dialog.c
@@ -236,10 +236,10 @@ screenshot_dialog_new (GdkPixbuf *screenshot,
   g_free (current_folder);
 
   gtk_widget_set_size_request (preview_darea, width, height);
+  height = gdk_pixbuf_get_height (screenshot);
+  width = gdk_pixbuf_get_width (screenshot);
   gtk_aspect_frame_set (GTK_ASPECT_FRAME (aspect_frame), 0.0, 0.5,
-			gdk_pixbuf_get_width (screenshot)/
-			(gfloat) gdk_pixbuf_get_height (screenshot),
-			FALSE);
+                        (gfloat) width / (gfloat) height, FALSE);
   g_signal_connect (toplevel, "key_press_event", G_CALLBACK (on_toplevel_key_press_event), dialog);
   g_signal_connect (preview_darea, "draw", G_CALLBACK (on_preview_draw), dialog);
   g_signal_connect (preview_darea, "button_press_event", G_CALLBACK (on_preview_button_press_event), dialog);


### PR DESCRIPTION
```
screenshot-dialog.c:241:4: warning: cast from function call of type ‘int’ to non-matching type ‘float’ [-Wbad-function-cast]
  241 |    (gfloat) gdk_pixbuf_get_height (screenshot),
      |    ^
--
gsearchtool-support.c:856:43: warning: cast from function call of type ‘int’ to non-matching type ‘float’ [-Wbad-function-cast]
  856 |     scale_factor_x = (gfloat) ICON_SIZE / (gfloat) gdk_pixbuf_get_width (thumbnail_pixbuf);
      |                                           ^
gsearchtool-support.c:859:43: warning: cast from function call of type ‘int’ to non-matching type ‘float’ [-Wbad-function-cast]
  859 |     scale_factor_y = (gfloat) ICON_SIZE / (gfloat) gdk_pixbuf_get_height (thumbnail_pixbuf);
      |                                           ^
--
gsearchtool.c:914:28: warning: cast from function call of type ‘goffset’ {aka ‘long int’} to non-matching type ‘double’ [-Wbad-function-cast]
  914 |        COLUMN_SIZE, (-1) * (gdouble) g_file_info_get_size(file_info),
      |                            ^
```