### PR TITLE
logview: Use test-reader test with log file path

### DIFF
--- a/logview/src/tests/test-reader.c
+++ b/logview/src/tests/test-reader.c
@@ -52,9 +52,48 @@ callback (LogviewLog *log,
 
 int main (int argc, char **argv)
 {
+  GError *error = NULL;
+  gchar *log_filename = NULL;
+  gchar *usage;
+  GOptionContext *context;
+  GOptionEntry entries [] =
+    { { "file", 'f', 0, G_OPTION_ARG_FILENAME, &log_filename, "The log file, e.g. /var/log/dpkg.log.2.gz", NULL },
+      { NULL } };
+
+  context = g_option_context_new (NULL);
+  g_option_context_add_main_entries (context, entries, NULL);
+
+  if (!g_option_context_parse (context, &argc, &argv, &error)) {
+    if (error) {
+      g_printerr ("%s\n\n", error->message);
+      g_error_free (error);
+    }
+    goto arg_error;
+  }
+
+  if (!log_filename) {
+    g_printerr ("ERROR: You must specify the log file.\n\n");
+    goto arg_error;
+  }
+
+  g_option_context_free (context);
+
   loop = g_main_loop_new (NULL, FALSE);
-  logview_log_create ("/var/log/dpkg.log.2.gz", callback, NULL);
+  logview_log_create (log_filename, callback, NULL);
+
   g_main_loop_run (loop);
 
+  g_main_loop_unref (loop);
+
+  g_free (log_filename);
+
   return 0;
+
+arg_error:
+  usage = g_option_context_get_help (context, TRUE, NULL);
+  g_printerr ("%s", usage);
+  g_free (usage);
+  g_option_context_free (context);
+
+  return 1;
 }


### PR DESCRIPTION
Test on fedora:
```
$ ./logview/src/tests/test-reader -f /var/log/dnf.log.2
```