### PR TITLE
mate-screenshot: Add delay for area screenshot

### DIFF
--- a/mate-screenshot/src/mate-screenshot.c
+++ b/mate-screenshot/src/mate-screenshot.c
@@ -1282,17 +1282,12 @@ loop_dialog_screenshot (void)
     }
   else
     {
-      if (interactive_arg)
-        {
-          /* HACK: give time to the dialog to actually disappear.
-           * We don't have any way to tell when the compositor has finished
-           * re-drawing.
-           */
-          g_timeout_add (200,
-                         prepare_screenshot_timeout, NULL);
-        }
-      else
-        g_idle_add (prepare_screenshot_timeout, NULL);
+      /* HACK: give time to the dialog to actually disappear.
+       * We don't have any way to tell when the compositor has finished
+       * re-drawing.
+       */
+      g_timeout_add (200,
+                     prepare_screenshot_timeout, NULL);
     }
 
   gtk_main ();


### PR DESCRIPTION
As described in #37, if a keyboard shortcut was used to screenshot an area, the command would not work. However, if a delay was added before the command, like `sleep 0.1 && mate-screenshot -a`, the screenshot would work.

The reason for that is that there needs to be a delay before executing an area screenshot. This delay was present when using the interactive mode, but missing on a pure `mate-screenshot -a` mode. Even though this would work in a terminal, if invoked by a shortcut would not work. I suspect that `g_idle_add` would not behave well with timings from `marco` and keypresses.

To test, add a new custom keyboard shortcut with the command `mate-screenshot -a`.

Fixes #37.