### PR TITLE
[WIP] Screenshot one screen, need review and help

### DIFF
--- a/logview/src/logview-log.c
+++ b/logview/src/logview-log.c
@@ -609,7 +609,6 @@ log_load (GIOSchedulerJob *io_job,
   const char *content_type;
   GFileType type;
   GError *err = NULL;
-  GTimeVal timeval;
   gboolean is_archive, can_read;
 
   info = g_file_query_info (f,
@@ -654,8 +653,15 @@ log_load (GIOSchedulerJob *io_job,
   }
 
   log->priv->file_size = g_file_info_get_size (info);
-  g_file_info_get_modification_time (info, &timeval);
-  log->priv->file_time = timeval.tv_sec;
+  #if GLIB_CHECK_VERSION(2,61,2)
+    GDateTime *file_dt;
+    log->priv->file_time = g_file_info_get_modification_date_time (info);
+  #else
+    GTimeVal time_val;
+    g_file_info_get_modification_time (info, &time_val);
+    log->priv->file_time = time_val.tv_sec;
+  #endif
+
   log->priv->display_name = g_strdup (g_file_info_get_display_name (info));
 
   g_object_unref (info);

--- a/logview/src/logview-log.c
+++ b/logview/src/logview-log.c
@@ -655,7 +655,11 @@ log_load (GIOSchedulerJob *io_job,
   log->priv->file_size = g_file_info_get_size (info);
   #if GLIB_CHECK_VERSION(2,61,2)
     GDateTime *file_dt;
-    log->priv->file_time = g_file_info_get_modification_date_time (info);
+    gint64 t;
+    file_dt = g_file_info_get_modification_date_time (info);
+    t = g_date_time_to_unix (file_dt);
+    g_date_time_unref (file_dt);
+    log->priv->file_time = t;
   #else
     GTimeVal time_val;
     g_file_info_get_modification_time (info, &time_val);

--- a/mate-screenshot/src/mate-screenshot.c
+++ b/mate-screenshot/src/mate-screenshot.c
@@ -407,6 +407,7 @@ create_screenshot_frame (GtkWidget   *outer_vbox,
   GtkAdjustment *adjust;
   GSList *group;
   gchar *title;
+  gint monitors_count;
 
   main_vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
   gtk_box_pack_start (GTK_BOX (outer_vbox), main_vbox, FALSE, FALSE, 0);
@@ -449,17 +450,23 @@ create_screenshot_frame (GtkWidget   *outer_vbox,
   group = gtk_radio_button_get_group (GTK_RADIO_BUTTON (radio));
   gtk_widget_show (radio);
 
-  /** Grab current monitor **/
-  radio = gtk_radio_button_new_with_mnemonic (group,
-                                              _("Grab the _screen where this application is"));
-  if (take_monitor_shot)
-    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (radio), TRUE);
-  g_signal_connect (radio, "toggled",
-                    G_CALLBACK (target_toggled_cb),
-                    GINT_TO_POINTER (TARGET_TOGGLE_MONITOR));
-  gtk_box_pack_start (GTK_BOX (vbox), radio, FALSE, FALSE, 0);
-  group = gtk_radio_button_get_group (GTK_RADIO_BUTTON (radio));
-  gtk_widget_show (radio);
+  /** Grab current monitor only if multiple monitors, hidden for one monitor only **/
+  take_monitor_shot = FALSE;
+  monitors_count = gdk_display_get_n_monitors (gdk_display_get_default ());
+
+  if (monitors_count > 1)
+  {
+    radio = gtk_radio_button_new_with_mnemonic (group,
+                                                _("Grab the _screen where this application is"));
+    if (take_monitor_shot)
+      gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (radio), TRUE);
+    g_signal_connect (radio, "toggled",
+                      G_CALLBACK (target_toggled_cb),
+                      GINT_TO_POINTER (TARGET_TOGGLE_MONITOR));
+    gtk_box_pack_start (GTK_BOX (vbox), radio, FALSE, FALSE, 0);
+    group = gtk_radio_button_get_group (GTK_RADIO_BUTTON (radio));
+    gtk_widget_show (radio);
+  }
 
   /** Grab current window **/
   radio = gtk_radio_button_new_with_mnemonic (group,

--- a/mate-screenshot/src/mate-screenshot.c
+++ b/mate-screenshot/src/mate-screenshot.c
@@ -101,6 +101,8 @@ static guint delay_arg = 0;
 
 /* Options */
 static gboolean noninteractive_clipboard_arg = FALSE;
+static gboolean take_desktop_shot = FALSE;
+static gboolean take_monitor_shot = FALSE;
 static gboolean take_window_shot = FALSE;
 static gboolean take_area_shot = FALSE;
 static gboolean include_border = FALSE;
@@ -159,8 +161,9 @@ interactive_dialog_response_cb (GtkDialog *dialog,
 }
 
 #define TARGET_TOGGLE_DESKTOP 0
-#define TARGET_TOGGLE_WINDOW  1
-#define TARGET_TOGGLE_AREA    2
+#define TARGET_TOGGLE_MONITOR 1
+#define TARGET_TOGGLE_WINDOW  2
+#define TARGET_TOGGLE_AREA    3
 
 static void
 target_toggled_cb (GtkToggleButton *button,
@@ -170,6 +173,8 @@ target_toggled_cb (GtkToggleButton *button,
 
   if (gtk_toggle_button_get_active (button))
     {
+      take_desktop_shot = (target_toggle == TARGET_TOGGLE_DESKTOP);
+      take_monitor_shot = (target_toggle == TARGET_TOGGLE_MONITOR);
       take_window_shot = (target_toggle == TARGET_TOGGLE_WINDOW);
       take_area_shot = (target_toggle == TARGET_TOGGLE_AREA);
 
@@ -435,11 +440,23 @@ create_screenshot_frame (GtkWidget   *outer_vbox,
   group = NULL;
   radio = gtk_radio_button_new_with_mnemonic (group,
                                               _("Grab the whole _desktop"));
-  if (take_window_shot || take_area_shot)
+  if (take_desktop_shot)
     gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (radio), FALSE);
   g_signal_connect (radio, "toggled",
                     G_CALLBACK (target_toggled_cb),
                     GINT_TO_POINTER (TARGET_TOGGLE_DESKTOP));
+  gtk_box_pack_start (GTK_BOX (vbox), radio, FALSE, FALSE, 0);
+  group = gtk_radio_button_get_group (GTK_RADIO_BUTTON (radio));
+  gtk_widget_show (radio);
+
+  /** Grab current monitor **/
+  radio = gtk_radio_button_new_with_mnemonic (group,
+                                              _("Grab the _screen where this application is"));
+  if (take_monitor_shot)
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (radio), TRUE);
+  g_signal_connect (radio, "toggled",
+                    G_CALLBACK (target_toggled_cb),
+                    GINT_TO_POINTER (TARGET_TOGGLE_MONITOR));
   gtk_box_pack_start (GTK_BOX (vbox), radio, FALSE, FALSE, 0);
   group = gtk_radio_button_get_group (GTK_RADIO_BUTTON (radio));
   gtk_widget_show (radio);
@@ -819,14 +836,14 @@ static void
 finish_prepare_screenshot (char *initial_uri, GdkWindow *window, GdkRectangle *rectangle)
 {
   ScreenshotDialog *dialog;
-  gboolean include_mask = (!take_window_shot && !take_area_shot);
+  gboolean include_mask = (!take_window_shot && !take_monitor_shot && !take_area_shot);
 
-  /* always disable window border for full-desktop or selected-area screenshots */
-  if (!take_window_shot)
-    screenshot = screenshot_get_pixbuf (window, rectangle, include_pointer, FALSE, include_mask);
+  /* always disable window border for full-desktop or monitor or selected-area screenshots */
+  if (take_desktop_shot || take_monitor_shot || take_area_shot)
+    screenshot = screenshot_get_pixbuf (window, rectangle, include_pointer, FALSE, include_mask, take_monitor_shot);
   else
     {
-      screenshot = screenshot_get_pixbuf (window, rectangle, include_pointer, include_border, include_mask);
+      screenshot = screenshot_get_pixbuf (window, rectangle, include_pointer, include_border, include_mask, FALSE);
 
       switch (border_effect[0])
         {

--- a/mate-screenshot/src/screenshot-utils.c
+++ b/mate-screenshot/src/screenshot-utils.c
@@ -599,7 +599,8 @@ screenshot_get_pixbuf (GdkWindow    *window,
                        GdkRectangle *rectangle,
                        gboolean      include_pointer,
                        gboolean      include_border,
-                       gboolean      include_mask)
+                       gboolean      include_mask,
+                       gboolean      current_monitor)
 {
   GdkWindow *root;
   GdkPixbuf *screenshot;
@@ -608,7 +609,6 @@ screenshot_get_pixbuf (GdkWindow    *window,
   gint screen_width, screen_height, scale;
 
   /* If the screenshot should include the border, we look for the WM window. */
-
   if (include_border)
     {
       Window xid, wm;
@@ -662,6 +662,25 @@ screenshot_get_pixbuf (GdkWindow    *window,
       y_orig = rectangle->y - y_orig;
       width  = rectangle->width;
       height = rectangle->height;
+    }
+
+  /* Change the area to grab if we want the screen where the application is */
+  if (current_monitor)
+    {
+      GdkWindow *current_window;
+      GdkDisplay *display;
+      GdkMonitor *monitor;
+      GdkRectangle geometry;
+
+      current_window = screenshot_find_active_window ();
+      display = gdk_window_get_display (current_window);
+      monitor = gdk_display_get_monitor_at_window (display, current_window);
+
+      gdk_monitor_get_geometry(monitor, &geometry);
+      x_orig = geometry.x;
+      y_orig = geometry.y;
+      width = geometry.width;
+      height = geometry.height;
     }
 
   screenshot = gdk_pixbuf_get_from_window (root,

--- a/mate-screenshot/src/screenshot-utils.c
+++ b/mate-screenshot/src/screenshot-utils.c
@@ -600,7 +600,7 @@ screenshot_get_pixbuf (GdkWindow    *window,
                        gboolean      include_pointer,
                        gboolean      include_border,
                        gboolean      include_mask,
-                       gboolean      current_monitor)
+                       gboolean      take_monitor_shot)
 {
   GdkWindow *root;
   GdkPixbuf *screenshot;
@@ -665,7 +665,7 @@ screenshot_get_pixbuf (GdkWindow    *window,
     }
 
   /* Change the area to grab if we want the screen where the application is */
-  if (current_monitor)
+  if (take_monitor_shot)
     {
       GdkWindow *current_window;
       GdkDisplay *display;

--- a/mate-screenshot/src/screenshot-utils.h
+++ b/mate-screenshot/src/screenshot-utils.h
@@ -35,7 +35,8 @@ GdkPixbuf *screenshot_get_pixbuf          (GdkWindow *win,
                                            GdkRectangle *rectangle,
                                            gboolean include_pointer,
                                            gboolean include_border,
-                                           gboolean include_mask);
+                                           gboolean include_mask,
+                                           gboolean current_monitor);
 
 void       screenshot_show_error_dialog   (GtkWindow   *parent,
                                            const gchar *message,

--- a/mate-screenshot/src/screenshot-utils.h
+++ b/mate-screenshot/src/screenshot-utils.h
@@ -36,7 +36,7 @@ GdkPixbuf *screenshot_get_pixbuf          (GdkWindow *win,
                                            gboolean include_pointer,
                                            gboolean include_border,
                                            gboolean include_mask,
-                                           gboolean current_monitor);
+                                           gboolean take_monitor_shot);
 
 void       screenshot_show_error_dialog   (GtkWindow   *parent,
                                            const gchar *message,


### PR DESCRIPTION
Hi,

I would like to fix #209 .

I need some informations to finish this PR.

The idea is to add a new radio button to allow screen capture only of the screen where mate-screenshot is, whole desktop could me capture in case of bug report too.
This new radio button is hidden is the user has only one monitor.

Added one string to translate in code, what about .pot file?
There is only one .pot file for several applications?l
Why not organize translations for each application in mate-utils, one .pot file by application?

After several tests, i can't correctly find the monitor for the mate-screenshot's GdkWindow.

Launching `mate-screenshot --interactive` from mate-terminal on the correct monitor, the correct screen is captured!

I still totally lost between GdkDisplay, GdkMonitor and GdkScreen...

Could some one, please, give me details on the different points here?

Thanks by advance.
Regards.