### PR TITLE
docbook: correct DE name

### DIFF
--- a/baobab/help/C/index.docbook
+++ b/baobab/help/C/index.docbook
@@ -56,7 +56,7 @@
       <author role="maintainer" lang="en"> 
 	<surname>MATE-Dokumentationsteam</surname> 
 	<affiliation> 
-	  <orgname>Mate desktop</orgname> 
+	  <orgname>MATE Desktop</orgname> 
 	</affiliation> 
       </author>
    <author> 
@@ -138,7 +138,7 @@
     <title>Introduction</title> 
 
       <para><application>&app;</application> is a graphical, menu-driven
-      application to analyze disk usage in any Mate environment. <application>&app;</application> can easily scan
+      application to analyze disk usage in any MATE environment. <application>&app;</application> can easily scan
        either the whole filesystem tree, or a specific user-requested directory 
        branch (local or remote). </para>
        <para>It also auto-detects in real-time any changes 
@@ -154,7 +154,7 @@
 
     <para><application>&app;</application> can be started in three ways:</para>
 	 <itemizedlist>
-    <listitem><para>from Mate menu <menuchoice><guimenu>Applications</guimenu><guimenuitem>Accessories</guimenuitem></menuchoice>;</para>
+    <listitem><para>from MATE menu <menuchoice><guimenu>Applications</guimenu><guimenuitem>Accessories</guimenuitem></menuchoice>;</para>
     		</listitem>
     <listitem><para>from a terminal window;</para>
     		</listitem>
@@ -167,8 +167,8 @@
   
 <para><command>mate-disk-usage-analyzer &lt;full_path_to_a_directory&gt;</command>, then press <keycap>Return</keycap>.</para>  
 <para></para> 
-	<para>If launched from Mate menu, <application>&app;</application> starts and remains in a stand-by state, waiting for user action.</para> 
-    <para>When you start <application>&app;</application> from the Mate Menu, the following window is displayed.</para>
+	<para>If launched from MATE menu, <application>&app;</application> starts and remains in a stand-by state, waiting for user action.</para> 
+    <para>When you start <application>&app;</application> from the MATE Menu, the following window is displayed.</para>
 
     <!-- ==== Figure ==== -->
       <figure id="baobab-fig"> 


### PR DESCRIPTION
Correct misspellings of MATE/MATE Desktop in help pages.