### PR TITLE
configure: remove warning about option 'subdir-objects' is disabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,7 @@ AC_INIT([mate-utils],
 AC_CONFIG_MACRO_DIR([m4])
 
 AC_CONFIG_HEADERS([config.h])
-AM_INIT_AUTOMAKE([1.11 foreign dist-xz no-dist-gzip check-news]) #the foreign flavour disables warnings if README, NEWS such files are not present which are issued in the default gnu flavour
+AM_INIT_AUTOMAKE([1.11 foreign subdir-objects dist-xz no-dist-gzip check-news]) #the foreign flavour disables warnings if README, NEWS such files are not present which are issued in the default gnu flavour
 AM_SILENT_RULES([yes])
 
 MATE_COMMON_INIT


### PR DESCRIPTION
```
$ grep "but option 'subdir-objects' is disabled" -B 1 mate-utils.conf.log 
logview/src/tests/Makefile.am:8: warning: source file '../logview-log.c' is in a subdirectory,
logview/src/tests/Makefile.am:8: but option 'subdir-objects' is disabled
--
logview/src/tests/Makefile.am:8: warning: source file '../logview-utils.c' is in a subdirectory,
logview/src/tests/Makefile.am:8: but option 'subdir-objects' is disabled
mate-dictionary/libgdict/Makefile.am:32: warning: source file '$(srcdir)/gdict-context.c' is in a subdirectory,
mate-dictionary/libgdict/Makefile.am:32: but option 'subdir-objects' is disabled
mate-dictionary/libgdict/Makefile.am:32: warning: source file '$(srcdir)/gdict-client-context.c' is in a subdirectory,
mate-dictionary/libgdict/Makefile.am:32: but option 'subdir-objects' is disabled
mate-dictionary/libgdict/Makefile.am:32: warning: source file '$(srcdir)/gdict-database-chooser.c' is in a subdirectory,
mate-dictionary/libgdict/Makefile.am:32: but option 'subdir-objects' is disabled
mate-dictionary/libgdict/Makefile.am:32: warning: source file '$(srcdir)/gdict-defbox.c' is in a subdirectory,
mate-dictionary/libgdict/Makefile.am:32: but option 'subdir-objects' is disabled
mate-dictionary/libgdict/Makefile.am:32: warning: source file '$(srcdir)/gdict-source-chooser.c' is in a subdirectory,
mate-dictionary/libgdict/Makefile.am:32: but option 'subdir-objects' is disabled
mate-dictionary/libgdict/Makefile.am:32: warning: source file '$(srcdir)/gdict-source-loader.c' is in a subdirectory,
mate-dictionary/libgdict/Makefile.am:32: but option 'subdir-objects' is disabled
mate-dictionary/libgdict/Makefile.am:32: warning: source file '$(srcdir)/gdict-source.c' is in a subdirectory,
mate-dictionary/libgdict/Makefile.am:32: but option 'subdir-objects' is disabled
mate-dictionary/libgdict/Makefile.am:32: warning: source file '$(srcdir)/gdict-speller.c' is in a subdirectory,
mate-dictionary/libgdict/Makefile.am:32: but option 'subdir-objects' is disabled
mate-dictionary/libgdict/Makefile.am:32: warning: source file '$(srcdir)/gdict-strategy-chooser.c' is in a subdirectory,
mate-dictionary/libgdict/Makefile.am:32: but option 'subdir-objects' is disabled
mate-dictionary/libgdict/Makefile.am:32: warning: source file '$(srcdir)/gdict-utils.c' is in a subdirectory,
mate-dictionary/libgdict/Makefile.am:32: but option 'subdir-objects' is disabled
```