### PR TITLE
gdict-utils: variable 'env_string' set but not used

### DIFF
--- a/mate-dictionary/libgdict/gdict-utils.c
+++ b/mate-dictionary/libgdict/gdict-utils.c
@@ -107,13 +107,11 @@ pre_parse_hook (GOptionContext  *context,
                 gpointer         data,
                 GError         **error)
 {
-  const char *env_string;
-
   if (gdict_is_initialized)
     return TRUE;
 
 #ifdef GDICT_ENABLE_DEBUG
-  env_string = g_getenv ("GDICT_DEBUG");
+  const char *env_string = g_getenv ("GDICT_DEBUG");
   if (env_string != NULL)
     {
       gdict_debug_flags =
@@ -121,8 +119,6 @@ pre_parse_hook (GOptionContext  *context,
                               gdict_debug_keys,
                               G_N_ELEMENTS (gdict_debug_keys));
     }
-#else
-  env_string = NULL;
 #endif /* GDICT_ENABLE_DEBUG */
 
   return TRUE;

--- a/mate-dictionary/libgdict/gdict-utils.c
+++ b/mate-dictionary/libgdict/gdict-utils.c
@@ -89,7 +89,7 @@ gdict_arg_no_debug_cb (const char *key,
                            G_N_ELEMENTS (gdict_debug_keys));
   return TRUE;
 }
-#endif /* CLUTTER_ENABLE_DEBUG */
+#endif /* GDICT_ENABLE_DEBUG */
 
 static GOptionEntry gdict_args[] = {
 #ifdef GDICT_ENABLE_DEBUG


### PR DESCRIPTION
Test 1: debug enabled
```
$ ./autogen.sh --prefix=/usr --enable-debug && make && sudo make install
$ GDICT_DEBUG="misc,context,dict,source,loader,chooser,speller" mate-dictionary
```
Test 2: debug disabled (default)
```
$ ./autogen.sh --prefix=/usr & make && sudo make install
$ mate-dictionary
```
warning:
```
./gdict-utils.c: In function 'pre_parse_hook':
./gdict-utils.c:110:15: warning: variable 'env_string' set but not used [-Wunused-but-set-variable]
  110 |   const char *env_string;
      |               ^~~~~~~~~~
```