### PR TITLE
Remove warnings about missing prototypes

### DIFF
--- a/baobab/src/baobab-chart.c
+++ b/baobab/src/baobab-chart.c
@@ -1170,7 +1170,7 @@ baobab_chart_query_tooltip (GtkWidget  *widget,
   return TRUE;
 }
 
-GdkPixbuf*
+static GdkPixbuf*
 baobab_chart_get_pixbuf (GtkWidget *widget)
 {
   gint w, h;

--- a/baobab/src/baobab-ringschart.c
+++ b/baobab/src/baobab-ringschart.c
@@ -363,7 +363,7 @@ baobab_ringschart_get_item_rectangle (GtkWidget *chart,
   item->rect = rect;
 }
 
-gboolean
+static gboolean
 baobab_ringschart_subfolder_tips_timeout (gpointer data)
 {
   BaobabRingschartPrivate *priv;
@@ -377,7 +377,7 @@ baobab_ringschart_subfolder_tips_timeout (gpointer data)
   return FALSE;
 }
 
-void
+static void
 baobab_ringschart_clean_subforlder_tips_state (GtkWidget *chart)
 {
   BaobabRingschartPrivate *priv;

--- a/baobab/src/baobab-scan.c
+++ b/baobab/src/baobab-scan.c
@@ -28,7 +28,7 @@
 
 #include "baobab.h"
 #include "baobab-utils.h"
-
+#include "baobab-scan.h"
 
 /*
    Hardlinks handling.

--- a/baobab/src/baobab-utils.c
+++ b/baobab/src/baobab-utils.c
@@ -69,7 +69,7 @@ baobab_get_filesystem (BaobabFS *fs)
 	g_free (mountentries);
 }
 
-void
+static void
 filechooser_cb (GtkWidget *chooser,
                 gint response,
                 gpointer data)

--- a/mate-dictionary/src/gdict-sidebar.c
+++ b/mate-dictionary/src/gdict-sidebar.c
@@ -71,7 +71,7 @@ static GQuark sidebar_page_id_quark = 0;
 
 G_DEFINE_TYPE_WITH_PRIVATE (GdictSidebar, gdict_sidebar, GTK_TYPE_BOX);
 
-SidebarPage *
+static SidebarPage *
 sidebar_page_new (const gchar *id,
 		  const gchar *name,
 		  GtkWidget   *widget)
@@ -89,7 +89,7 @@ sidebar_page_new (const gchar *id,
   return page;
 }
 
-void
+static void
 sidebar_page_free (SidebarPage *page)
 {
   if (G_LIKELY (page))


### PR DESCRIPTION
```
baobab-scan.c:340:1: warning: no previous prototype for ‘baobab_scan_execute’ [-Wmissing-prototypes]
baobab-ringschart.c:367:1: warning: no previous prototype for ‘baobab_ringschart_subfolder_tips_timeout’ [-Wmissing-prototypes]
baobab-ringschart.c:381:1: warning: no previous prototype for ‘baobab_ringschart_clean_subforlder_tips_state’ [-Wmissing-prototypes]
baobab-utils.c:73:1: warning: no previous prototype for ‘filechooser_cb’ [-Wmissing-prototypes]
baobab-chart.c:1174:1: warning: no previous prototype for ‘baobab_chart_get_pixbuf’ [-Wmissing-prototypes]
gdict-sidebar.c:75:1: warning: no previous prototype for ‘sidebar_page_new’ [-Wmissing-prototypes]
gdict-sidebar.c:93:1: warning: no previous prototype for ‘sidebar_page_free’ [-Wmissing-prototypes]
```