### PR TITLE
logview: converting the enum constant to a boolean

### DIFF
--- a/logview/src/logview-app.c
+++ b/logview/src/logview-app.c
@@ -185,7 +185,7 @@ enumerate_next_files_async_cb (GObject *source,
       continue;
     }
 
-    if (type != (G_FILE_TYPE_REGULAR || G_FILE_TYPE_SYMBOLIC_LINK) ||
+    if (((type != G_FILE_TYPE_REGULAR) && (type != G_FILE_TYPE_SYMBOLIC_LINK)) ||
         !g_content_type_is_a (content_type, "text/plain"))
     {
       g_object_unref (info);

--- a/logview/src/logview-log.c
+++ b/logview/src/logview-log.c
@@ -643,7 +643,7 @@ log_load (GIOSchedulerJob *io_job,
 
   is_archive = g_content_type_equals (content_type, "application/x-gzip");
 
-  if (type != (G_FILE_TYPE_REGULAR || G_FILE_TYPE_SYMBOLIC_LINK) ||
+  if (((type != G_FILE_TYPE_REGULAR) && (type != G_FILE_TYPE_SYMBOLIC_LINK)) ||
       (!g_content_type_is_a (content_type, "text/plain") && !is_archive))
   {
     err = g_error_new_literal (LOGVIEW_ERROR_QUARK, LOGVIEW_ERROR_NOT_A_LOG,


### PR DESCRIPTION
```
logview-app.c:188:38: warning: converting the enum constant to a boolean [-Wint-in-bool-context]
    if (type != (G_FILE_TYPE_REGULAR || G_FILE_TYPE_SYMBOLIC_LINK) ||
                                     ^
```
```
logview-log.c:646:36: warning: converting the enum constant to a boolean [-Wint-in-bool-context]
  if (type != (G_FILE_TYPE_REGULAR || G_FILE_TYPE_SYMBOLIC_LINK) ||
                                   ^
```