### PR TITLE
gsearchtool: fix memory leak

### DIFF
--- a/gsearchtool/src/gsearchtool-support.c
+++ b/gsearchtool/src/gsearchtool-support.c
@@ -446,10 +446,10 @@ get_file_type_description (const gchar * file,
 	}
 
 	if (content_type == NULL || g_content_type_is_unknown (content_type) == TRUE) {
-		return g_strdup (g_content_type_get_description ("application/octet-stream"));
+		return g_content_type_get_description ("application/octet-stream");
 	}
 
-	desc = g_strdup (g_content_type_get_description (content_type));
+	desc = g_content_type_get_description (content_type);
 
 	if (g_file_info_get_is_symlink (file_info) == TRUE) {
 


### PR DESCRIPTION
```
Direct leak of 9534 byte(s) in 811 object(s) allocated from:
    #0 0x7fc3c3ab393f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7fc3c2a4d1bf in g_malloc ../glib/gmem.c:106
    #2 0x7fc3c2a4d502 in g_malloc_n ../glib/gmem.c:344
    #3 0x7fc3c2a6f995 in g_strdup ../glib/gstrfuncs.c:364
    #4 0x7fc3c2cc2d2f in g_content_type_get_description ../gio/gcontenttype.c:481
    #5 0x40e88f in get_file_type_description /home/robert/builddir.gcc/mate-utils/gsearchtool/src/gsearchtool-support.c:452
    #6 0x41fe9b in add_file_to_search_results /home/robert/builddir.gcc/mate-utils/gsearchtool/src/gsearchtool.c:880
    #7 0x42356c in handle_search_command_stdout_io /home/robert/builddir.gcc/mate-utils/gsearchtool/src/gsearchtool.c:1566
    #8 0x7fc3c2ab8c18 in g_io_unix_dispatch ../glib/giounix.c:166
    #9 0x7fc3c2a43e16 in g_main_dispatch ../glib/gmain.c:3381
    #10 0x7fc3c2a43c5f in g_main_context_dispatch ../glib/gmain.c:4099
    #11 0x7fc3c2a44181 in g_main_context_iterate ../glib/gmain.c:4175
    #12 0x7fc3c2a446a2 in g_main_loop_run ../glib/gmain.c:4373
    #13 0x7fc3c33f9e1c in gtk_main (/lib64/libgtk-3.so.0+0x248e1c)
```
```
Direct leak of 105 byte(s) in 8 object(s) allocated from:
    #0 0x7fc3c3ab393f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7fc3c2a4d1bf in g_malloc ../glib/gmem.c:106
    #2 0x7fc3c2a4d502 in g_malloc_n ../glib/gmem.c:344
    #3 0x7fc3c2a6fabc in g_strndup ../glib/gstrfuncs.c:461
    #4 0x7fc3c2cc3e3e in mime_info_text ../gio/gcontenttype.c:391
    #5 0x7fc3c2a48750 in g_markup_parse_context_parse ../glib/gmarkup.c:1549
    #6 0x7fc3c2cc3c82 in load_comment_for_mime_helper ../gio/gcontenttype.c:421
    #7 0x7fc3c2cc2e1a in load_comment_for_mime ../gio/gcontenttype.c:445
    #8 0x7fc3c2cc2d60 in g_content_type_get_description ../gio/gcontenttype.c:487
    #9 0x40e88f in get_file_type_description /home/robert/builddir.gcc/mate-utils/gsearchtool/src/gsearchtool-support.c:452
    #10 0x41fe9b in add_file_to_search_results /home/robert/builddir.gcc/mate-utils/gsearchtool/src/gsearchtool.c:880
    #11 0x42356c in handle_search_command_stdout_io /home/robert/builddir.gcc/mate-utils/gsearchtool/src/gsearchtool.c:1566
    #12 0x7fc3c2ab8c18 in g_io_unix_dispatch ../glib/giounix.c:166
    #13 0x7fc3c2a43e16 in g_main_dispatch ../glib/gmain.c:3381
    #14 0x7fc3c2a43c5f in g_main_context_dispatch ../glib/gmain.c:4099
    #15 0x7fc3c2a44181 in g_main_context_iterate ../glib/gmain.c:4175
    #16 0x7fc3c2a446a2 in g_main_loop_run ../glib/gmain.c:4373
    #17 0x7fc3c33f9e1c in gtk_main (/lib64/libgtk-3.so.0+0x248e1c)
```