### PR TITLE
mate-dictionary: fix memory leak

### DIFF
--- a/mate-dictionary/src/gdict-app.c
+++ b/mate-dictionary/src/gdict-app.c
@@ -359,6 +359,7 @@ gdict_init (int *argc, char ***argv)
 
       exit (1);
     }
+  g_option_context_free (context);
 
   g_set_application_name (_("Dictionary"));
   gtk_window_set_default_icon_name ("accessories-dictionary");


### PR DESCRIPTION
```
Direct leak of 88 byte(s) in 1 object(s) allocated from:
    #0 0x7f5c72982af7 in calloc (/lib64/libasan.so.6+0xaeaf7)
    #1 0x7f5c71781244 in g_malloc0 ../glib/gmem.c:136
    #2 0x7f5c71781592 in g_malloc0_n ../glib/gmem.c:368
    #3 0x7f5c7178828a in g_option_context_new ../glib/goption.c:365
    #4 0x40c351 in gdict_init /home/robert/builddir.gcc/mate-utils/mate-dictionary/src/gdict-app.c:339
    #5 0x424b39 in main /home/robert/builddir.gcc/mate-utils/mate-dictionary/src/main.c:36
    #6 0x7f5c71542b74 in __libc_start_main (/lib64/libc.so.6+0x27b74)
```
```
Indirect leak of 288 byte(s) in 1 object(s) allocated from:
    #0 0x7f5c72982cb8 in __interceptor_realloc (/lib64/libasan.so.6+0xaecb8)
    #1 0x7f5c717812d7 in g_realloc ../glib/gmem.c:171
    #2 0x7f5c7178162a in g_realloc_n ../glib/gmem.c:394
    #3 0x7f5c71788f78 in g_option_group_add_entries ../glib/goption.c:2418
    #4 0x7f5c71788da1 in g_option_context_add_main_entries ../glib/goption.c:669
    #5 0x40c38a in gdict_init /home/robert/builddir.gcc/mate-utils/mate-dictionary/src/gdict-app.c:344
    #6 0x424b39 in main /home/robert/builddir.gcc/mate-utils/mate-dictionary/src/main.c:36
    #7 0x7f5c71542b74 in __libc_start_main (/lib64/libc.so.6+0x27b74)

Indirect leak of 112 byte(s) in 1 object(s) allocated from:
    #0 0x7f5c72982af7 in calloc (/lib64/libasan.so.6+0xaeaf7)
    #1 0x7f5c71781244 in g_malloc0 ../glib/gmem.c:136
    #2 0x7f5c71781592 in g_malloc0_n ../glib/gmem.c:368
    #3 0x7f5c71788dea in g_option_group_new ../glib/goption.c:2314
    #4 0x7f5c71788d85 in g_option_context_add_main_entries ../glib/goption.c:667
    #5 0x40c38a in gdict_init /home/robert/builddir.gcc/mate-utils/mate-dictionary/src/gdict-app.c:344
    #6 0x424b39 in main /home/robert/builddir.gcc/mate-utils/mate-dictionary/src/main.c:36
    #7 0x7f5c71542b74 in __libc_start_main (/lib64/libc.so.6+0x27b74)

Indirect leak of 33 byte(s) in 1 object(s) allocated from:
    #0 0x7f5c7298293f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7f5c717811bf in g_malloc ../glib/gmem.c:106
    #2 0x7f5c71781502 in g_malloc_n ../glib/gmem.c:344
    #3 0x7f5c717a3995 in g_strdup ../glib/gstrfuncs.c:364
    #4 0x7f5c717882ba in g_option_context_new ../glib/goption.c:372
    #5 0x40c351 in gdict_init /home/robert/builddir.gcc/mate-utils/mate-dictionary/src/gdict-app.c:339
    #6 0x424b39 in main /home/robert/builddir.gcc/mate-utils/mate-dictionary/src/main.c:36
    #7 0x7f5c71542b74 in __libc_start_main (/lib64/libc.so.6+0x27b74)

Indirect leak of 11 byte(s) in 1 object(s) allocated from:
    #0 0x7f5c7298293f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7f5c717811bf in g_malloc ../glib/gmem.c:106
    #2 0x7f5c71781502 in g_malloc_n ../glib/gmem.c:344
    #3 0x7f5c717a3995 in g_strdup ../glib/gstrfuncs.c:364
    #4 0x7f5c71789244 in g_option_group_set_translation_domain ../glib/goption.c:2565
    #5 0x7f5c71788db2 in g_option_context_add_main_entries ../glib/goption.c:670
    #6 0x40c38a in gdict_init /home/robert/builddir.gcc/mate-utils/mate-dictionary/src/gdict-app.c:344
    #7 0x424b39 in main /home/robert/builddir.gcc/mate-utils/mate-dictionary/src/main.c:36
    #8 0x7f5c71542b74 in __libc_start_main (/lib64/libc.so.6+0x27b74)

Indirect leak of 11 byte(s) in 1 object(s) allocated from:
    #0 0x7f5c7298293f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7f5c717811bf in g_malloc ../glib/gmem.c:106
    #2 0x7f5c71781502 in g_malloc_n ../glib/gmem.c:344
    #3 0x7f5c717a3995 in g_strdup ../glib/gstrfuncs.c:364
    #4 0x7f5c7178c4f4 in g_option_context_set_translation_domain ../glib/goption.c:2624
    #5 0x40c36c in gdict_init /home/robert/builddir.gcc/mate-utils/mate-dictionary/src/gdict-app.c:342
    #6 0x424b39 in main /home/robert/builddir.gcc/mate-utils/mate-dictionary/src/main.c:36
    #7 0x7f5c71542b74 in __libc_start_main (/lib64/libc.so.6+0x27b74)
```