### PR TITLE
Fix build warnings about missing field initializer

### DIFF
--- a/baobab/src/baobab.c
+++ b/baobab/src/baobab.c
@@ -1223,7 +1223,7 @@ main (int argc, char *argv[])
 	const GOptionEntry options[] = {
 		{"version", 'V', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, show_version, N_("Show version"), NULL},
 		{G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &directories, NULL, N_("[DIRECTORY]")},
-		{NULL}
+		{ NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
 	};
 	GOptionContext *context;
 	GError *error = NULL;

--- a/gsearchtool/src/gsearchtool-callbacks.c
+++ b/gsearchtool/src/gsearchtool-callbacks.c
@@ -221,7 +221,7 @@ click_expander_cb (GObject * object,
 		                               GDK_HINT_MIN_SIZE);
 	}
 	else {
-		GdkGeometry default_geometry = {MINIMUM_WINDOW_WIDTH, MINIMUM_WINDOW_HEIGHT};
+		GdkGeometry default_geometry = { MINIMUM_WINDOW_WIDTH, MINIMUM_WINDOW_HEIGHT, 0, 0, 0, 0, 0, 0, 0.0, 0.0, 0 };
 
 		gtk_widget_hide (gsearch->available_options_vbox);
 		gtk_window_set_geometry_hints (GTK_WINDOW (gsearch->window),

--- a/gsearchtool/src/gsearchtool.c
+++ b/gsearchtool/src/gsearchtool.c
@@ -175,7 +175,7 @@ static GOptionEntry GSearchGOptionEntries[] = {
 	{ "hidden", 0, 0, G_OPTION_ARG_NONE, &GSearchGOptionArguments.hidden, NULL, NULL },
 	{ "follow", 0, 0, G_OPTION_ARG_NONE, &GSearchGOptionArguments.follow, NULL, NULL },
 	{ "mounts", 0, 0, G_OPTION_ARG_NONE, &GSearchGOptionArguments.mounts, NULL, NULL },
-	{ NULL }
+	{ NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
 };
 
 static gchar * find_command_default_name_argument;
@@ -3008,7 +3008,8 @@ gsearch_window_get_type (void)
 			NULL,
 			sizeof (GSearchWindow),
 			0,
-			(GInstanceInitFunc)(void (*)(void)) gsearch_app_create
+			(GInstanceInitFunc)(void (*)(void)) gsearch_app_create,
+			NULL
 		};
 		object_type = g_type_register_static (GTK_TYPE_WINDOW, "GSearchWindow", &object_info, 0);
 	}

--- a/logview/src/logview-main.c
+++ b/logview/src/logview-main.c
@@ -64,7 +64,7 @@ create_option_context (void)
       logview_show_version_and_quit, N_("Show the application's version"), NULL },
     { G_OPTION_REMAINING, '\0', 0, G_OPTION_ARG_FILENAME_ARRAY, &log_files,
       NULL, N_("[LOGFILE...]") },
-    { NULL },
+    { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL },
   };
 
   context = g_option_context_new (_(" - Browse and monitor logs"));

--- a/mate-dictionary/libgdict/gdict-context.c
+++ b/mate-dictionary/libgdict/gdict-context.c
@@ -68,6 +68,10 @@ gdict_context_get_type (void)
         (GClassInitFunc) gdict_context_class_init,
         NULL,                       /* class_finalize */
         NULL,                       /* class_data */
+        0,                          /* instance_size */
+        0,                          /* n_preallocs */
+        NULL,                       /* instance_init */
+        NULL                        /* value_table */
       };
 
       context_type = g_type_register_static (G_TYPE_INTERFACE,

--- a/mate-dictionary/libgdict/gdict-utils.c
+++ b/mate-dictionary/libgdict/gdict-utils.c
@@ -98,7 +98,7 @@ static GOptionEntry gdict_args[] = {
   { "gdict-no-debug", 0, 0, G_OPTION_ARG_CALLBACK, gdict_arg_no_debug_cb,
     N_("GDict debugging flags to unset"), N_("FLAGS") },
 #endif /* GDICT_ENABLE_DEBUG */
-  { NULL, },
+  { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL },
 };
 
 static gboolean

--- a/mate-dictionary/src/gdict-app.c
+++ b/mate-dictionary/src/gdict-app.c
@@ -331,7 +331,7 @@ gdict_init (int *argc, char ***argv)
        N_("Database to use"), N_("db") },
     { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_STRING_ARRAY, &lookup_words,
        N_("Words to look up"), N_("word") },
-    { NULL },
+    { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL },
   };
 
   g_assert (singleton == NULL);

--- a/mate-disk-image-mounter/src/main.c
+++ b/mate-disk-image-mounter/src/main.c
@@ -79,7 +79,7 @@ static gboolean  opt_writable = FALSE;
 static const GOptionEntry opt_entries[] =
 {
   { "writable", 'w', 0, G_OPTION_ARG_NONE, &opt_writable, N_("Allow writing to the image"), NULL},
-  { NULL }
+  { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
 };
 
 /* ---------------------------------------------------------------------------------------------------- */

--- a/mate-screenshot/src/mate-screenshot.c
+++ b/mate-screenshot/src/mate-screenshot.c
@@ -1321,7 +1321,7 @@ main (int argc, char *argv[])
     { "border-effect", 'e', 0, G_OPTION_ARG_STRING, &border_effect_arg, N_("Effect to add to the border (shadow, border or none)"), N_("effect") },
     { "interactive", 'i', 0, G_OPTION_ARG_NONE, &interactive_arg, N_("Interactively set options"), NULL },
     { "version", 0, 0, G_OPTION_ARG_NONE, &version_arg, N_("Print version information and exit"), NULL },
-    { NULL },
+    { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL },
   };
 
 #ifdef ENABLE_NLS


### PR DESCRIPTION
```
baobab.c:1226:8: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
                {NULL}
                     ^
--
gdict-context.c:71:7: warning: missing field 'instance_size' initializer [-Wmissing-field-initializers]
      };
      ^
--
gdict-utils.c:101:11: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
  { NULL, },
          ^
--
gdict-app.c:334:12: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
    { NULL },
           ^
--
mate-screenshot.c:1324:12: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
    { NULL },
           ^
--
gsearchtool-callbacks.c:224:78: warning: missing field 'max_width' initializer [-Wmissing-field-initializers]
                GdkGeometry default_geometry = {MINIMUM_WINDOW_WIDTH, MINIMUM_WINDOW_HEIGHT};
                                                                                           ^
--
gsearchtool.c:178:9: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
        { NULL }
               ^
--
gsearchtool.c:3012:3: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
                };
                ^
--
logview-main.c:67:12: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
    { NULL },
           ^
--
main.c:82:10: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
  { NULL }
         ^
```