### PR TITLE
mate-screenshot: fix memory leak

### DIFF
--- a/mate-screenshot/src/mate-screenshot.c
+++ b/mate-screenshot/src/mate-screenshot.c
@@ -1178,8 +1178,10 @@ load_options (void)
   /* Find various dirs */
   last_save_dir = g_settings_get_string (settings,
                                          LAST_SAVE_DIRECTORY_KEY);
-  if (!last_save_dir || !last_save_dir[0])
+
+  if (*last_save_dir == '\0')
     {
+      g_free (last_save_dir);
       last_save_dir = get_desktop_dir ();
     }
   else if (last_save_dir[0] == '~')


### PR DESCRIPTION
Test:
```
gsettings set org.mate.screenshot last-save-directory ''
```
```
LeakSanitizer: detected memory leaks

Direct leak of 1 byte(s) in 1 object(s) allocated from:
    #0 0x7f860bd0193f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7f860ab424ff in g_malloc ../glib/gmem.c:106
    #2 0x7f860ab42842 in g_malloc_n ../glib/gmem.c:344
    #3 0x7f860ab64d85 in g_strdup ../glib/gstrfuncs.c:364
    #4 0x7f860ab930d4 in g_variant_dup_string ../glib/gvariant.c:1543
    #5 0x7f860adf8aed in g_settings_get_string ../gio/gsettings.c:1807
    #6 0x40bd28 in load_options /home/robert/builddir.gcc/mate-utils/mate-screenshot/src/mate-screenshot.c:1181
    #7 0x40cf31 in main /home/robert/builddir.gcc/mate-utils/mate-screenshot/src/mate-screenshot.c:1372
    #8 0x7f860a7bdb74 in __libc_start_main (/lib64/libc.so.6+0x27b74)
```