### PR TITLE
Redundant null check before freeing the variable

### DIFF
--- a/logview/src/logview-utils.c
+++ b/logview/src/logview-utils.c
@@ -270,9 +270,7 @@ log_read_dates (const char **buffer_lines, time_t current)
     }
   }
 
-  if (date_string) {
-    g_free (date_string);
-  }
+  g_free (date_string);
 
   /* sort the days in chronological order */
   days = g_slist_sort (days, days_compare);

--- a/mate-dictionary/libgdict/gdict-client-context.c
+++ b/mate-dictionary/libgdict/gdict-client-context.c
@@ -407,8 +407,7 @@ gdict_client_context_set_property (GObject      *object,
   switch (prop_id)
     {
     case PROP_HOSTNAME:
-      if (priv->hostname)
-        g_free (priv->hostname);
+      g_free (priv->hostname);
       priv->hostname = g_strdup (g_value_get_string (value));
       gdict_client_context_clear_hostinfo (GDICT_CLIENT_CONTEXT (object));
       break;
@@ -416,8 +415,7 @@ gdict_client_context_set_property (GObject      *object,
       priv->port = g_value_get_uint (value);
       break;
     case PROP_CLIENT_NAME:
-      if (priv->client_name)
-        g_free (priv->client_name);
+      g_free (priv->client_name);
       priv->client_name = g_strdup (g_value_get_string (value));
       break;
     case GDICT_CONTEXT_PROP_LOCAL_ONLY:
@@ -469,8 +467,7 @@ gdict_client_context_finalize (GObject *object)
   /* force disconnection */
   gdict_client_context_force_disconnect (context);
 
-  if (priv->command)
-    gdict_command_free (priv->command);
+  gdict_command_free (priv->command);
 
   if (priv->commands_queue)
     {
@@ -479,11 +476,8 @@ gdict_client_context_finalize (GObject *object)
       priv->commands_queue = NULL;
     }
 
-  if (priv->client_name)
-    g_free (priv->client_name);
-
-  if (priv->hostname)
-    g_free (priv->hostname);
+  g_free (priv->client_name);
+  g_free (priv->hostname);
 
 #ifdef ENABLE_IPV6
   if (priv->host6info)

--- a/mate-dictionary/libgdict/gdict-source.c
+++ b/mate-dictionary/libgdict/gdict-source.c
@@ -395,8 +395,7 @@ gdict_source_create_context (GdictSource           *source,
 
       context = gdict_client_context_new (hostname, port);
 
-      if (hostname)
-        g_free (hostname);
+      g_free (hostname);
       }
       break;
     default:


### PR DESCRIPTION
`g_free` and `gdict_command_free` already check that the variable is not null before freeing memory.