### PR TITLE
mate-dictionary: fix memory leak

### DIFF
--- a/mate-dictionary/src/gdict-window.c
+++ b/mate-dictionary/src/gdict-window.c
@@ -127,7 +127,6 @@ gdict_window_dispose (GObject *gobject)
   if (window->settings != NULL)
     {
       g_object_unref (window->settings);
-
       window->settings = NULL;
     }
 
@@ -185,6 +184,8 @@ gdict_window_dispose (GObject *gobject)
       g_object_unref (window->busy_cursor);
       window->busy_cursor = NULL;
     }
+
+  g_clear_pointer (&window->sidebar_page, g_free);
 
   G_OBJECT_CLASS (gdict_window_parent_class)->dispose (gobject);
 }


### PR DESCRIPTION
```
Direct leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7f5c7298293f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7f5c717811bf in g_malloc ../glib/gmem.c:106
    #2 0x7f5c71781502 in g_malloc_n ../glib/gmem.c:344
    #3 0x7f5c7176bab4 in g_key_file_parse_value_as_string ../glib/gkeyfile.c:4272
    #4 0x7f5c7176b9d7 in g_key_file_get_string ../glib/gkeyfile.c:1962
    #5 0x41dc01 in gdict_window_load_state /home/robert/builddir.gcc/mate-utils/mate-dictionary/src/gdict-window.c:886
    #6 0x421b3d in gdict_window_constructor /home/robert/builddir.gcc/mate-utils/mate-dictionary/src/gdict-window.c:1617
    #7 0x7f5c7189ccc1 in g_object_new_with_custom_constructor ../gobject/gobject.c:1863
    #8 0x7f5c71896bbf in g_object_new_internal ../gobject/gobject.c:1943
    #9 0x7f5c71896940 in g_object_new_valist ../gobject/gobject.c:2288
    #10 0x7f5c71895f31 in g_object_new ../gobject/gobject.c:1788
    #11 0x424611 in gdict_window_new /home/robert/builddir.gcc/mate-utils/mate-dictionary/src/gdict-window.c:2036
    #12 0x40abf9 in gdict_create_window /home/robert/builddir.gcc/mate-utils/mate-dictionary/src/gdict-app.c:135
    #13 0x40cae0 in gdict_main /home/robert/builddir.gcc/mate-utils/mate-dictionary/src/gdict-app.c:417
    #14 0x424b3e in main /home/robert/builddir.gcc/mate-utils/mate-dictionary/src/main.c:38
    #15 0x7f5c71542b74 in __libc_start_main (/lib64/libc.so.6+0x27b74)
```