### PR TITLE
mate-dictionary: fix memory leak

### DIFF
--- a/mate-dictionary/libgdict/gdict-defbox.c
+++ b/mate-dictionary/libgdict/gdict-defbox.c
@@ -200,6 +200,8 @@ gdict_defbox_dispose (GObject *gobject)
       priv->regular_cursor = NULL;
     }
 
+  g_clear_pointer (&priv->word, g_free);
+
   G_OBJECT_CLASS (gdict_defbox_parent_class)->dispose (gobject);
 }
 
@@ -2548,6 +2550,7 @@ gdict_defbox_lookup (GdictDefbox *defbox,
   				       G_CALLBACK (error_cb),
   				       defbox);
 
+  g_free (priv->word);
   priv->word = g_strdup (word);
   g_object_notify (G_OBJECT (defbox), "word");
 


### PR DESCRIPTION
```
Direct leak of 5 byte(s) in 1 object(s) allocated from:
    #0 0x7fcdd05dc93f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7fcdcf3db1bf in g_malloc ../glib/gmem.c:106
    #2 0x7fcdcf3db502 in g_malloc_n ../glib/gmem.c:344
    #3 0x7fcdcf3fd995 in g_strdup ../glib/gstrfuncs.c:364
    #4 0x7fcdd03aa9c0 in gdict_defbox_lookup /home/robert/builddir.gcc/mate-utils/mate-dictionary/libgdict/gdict-defbox.c:2551
    #5 0x41bcf0 in gdict_window_set_word /home/robert/builddir.gcc/mate-utils/mate-dictionary/src/gdict-window.c:586
    #6 0x4209f4 in lookup_word /home/robert/builddir.gcc/mate-utils/mate-dictionary/src/gdict-window.c:1371
    #7 0x7fcdcf4ea03f in g_cclosure_marshal_VOID__VOID ../gobject/gmarshal.c:117
    #8 0x7fcdcf4e6354 in g_closure_invoke ../gobject/gclosure.c:830
    #9 0x7fcdcf506d92 in signal_emit_unlocked_R ../gobject/gsignal.c:3742
    #10 0x7fcdcf506612 in g_signal_emitv ../gobject/gsignal.c:3227
    #11 0x7fcdcfc679a3 in gtk_binding_entry_activate (/lib64/libgtk-3.so.0+0x1289a3)
```