### PR TITLE
baobab: Fix -Wmissing-prototypes warnings

### DIFF
--- a/baobab/src/callbacks.h
+++ b/baobab/src/callbacks.h
@@ -28,6 +28,8 @@ void on_about_activate (GtkMenuItem *menuitem, gpointer user_data);
 void on_menuscanhome_activate (GtkMenuItem *menuitem, gpointer user_data);
 void on_menuallfs_activate (GtkMenuItem *menuitem, gpointer user_data);
 void on_menuscandir_activate (GtkMenuItem *menuitem, gpointer user_data);
+void on_menu_collapse_activate (GtkMenuItem *menuitem, gpointer user_data);
+void on_menu_expand_activate (GtkMenuItem *menuitem, gpointer user_data);
 void on_menu_stop_activate (GtkMenuItem *menuitem, gpointer user_data);
 void on_menu_rescan_activate (GtkMenuItem *menuitem, gpointer user_data);
 void on_tbscandir_clicked (GtkToolButton *toolbutton, gpointer user_data);


### PR DESCRIPTION
Test:
```
 CFLAGS="-Werror=missing-prototypes" ./autogen.sh --prefix=/usr && make && sudo make install
```
Warnings:
```
callbacks.c:120:1: error: no previous prototype for function 'on_menu_expand_activate' [-Werror,-Wmissing-prototypes]
on_menu_expand_activate (GtkMenuItem *menuitem, gpointer user_data)
^
callbacks.c:119:1: note: declare 'static' if the function is not intended to be used outside of this translation unit
void
^
static
```
```
callbacks.c:126:1: error: no previous prototype for function 'on_menu_collapse_activate' [-Werror,-Wmissing-prototypes]
on_menu_collapse_activate (GtkMenuItem *menuitem, gpointer user_data)
^
callbacks.c:125:1: note: declare 'static' if the function is not intended to be used outside of this translation unit
void
^
static
```