### PR TITLE
mate-dictionary: Replace deprecated functions fix compilation warnings

### DIFF
--- a/mate-dictionary/data/mate-dictionary-ui.xml
+++ b/mate-dictionary/data/mate-dictionary-ui.xml
@@ -1,48 +1,388 @@
-<ui>
-  <menubar name="MainMenu">
-    <menu name="FileMenu" action="File">
-      <menuitem name="NewMenu" action="FileNew"/>
-      <menuitem name="SaveAsMenu" action="FileSaveAs"/>
-      <separator/>
-      <menuitem name="FilePreviewMenu" action="FilePreview"/>
-      <menuitem name="FilePrintMenu" action="FilePrint"/>
-      <separator/>
-      <menuitem name="FileCloseWindowMenu" action="FileCloseWindow"/>
-    </menu>
-    <menu name="EditMenu" action="Edit">
-      <menuitem name="EditCopyMenu" action="EditCopy"/>
-      <separator/>
-      <menuitem name="EditSelectAllMenu" action="EditSelectAll"/>
-      <separator/>
-      <menuitem name="EditFindMenu" action="EditFind"/>
-      <menuitem name="EditFindNextMenu" action="EditFindNext"/>
-      <menuitem name="EditFindPreviousMenu" action="EditFindPrevious"/>
-      <separator/>
-      <menuitem name="EditPreferencesMenu" action="EditPreferences"/>
-    </menu>
-    <menu name="ViewMenu" action="View">
-      <menuitem name="ViewSidebarMenu" action="ViewSidebar"/>
-      <menuitem name="ViewStatusbarMenu" action="ViewStatusbar"/>
-      <separator/>
-      <menuitem name="ViewSpellerMenu" action="ViewSpeller"/>
-      <menuitem name="ViewSourceMenu" action="ViewSource"/>
-      <menuitem name="ViewDBMenu" action="ViewDB"/>
-      <menuitem name="ViewStratMenu" action="ViewStrat"/>
-    </menu>
-    <menu name="GoMenu" action="Go">
-      <menuitem name="GoPreviousDefMenu" action="GoPreviousDef"/>
-      <menuitem name="GoNextDefMenu" action="GoNextDef"/>
-      <separator/>
-      <menuitem name="GoFirstDefMenu" action="GoFirstDef"/>
-      <menuitem name="GoLastDefMenu" action="GoLastDef"/>
-    </menu>
-    <menu name="HelpMenu" action="Help">
-      <menuitem name="HelpContentsMenu" action="HelpContents"/>
-      <menuitem name="HelpAboutMenu" action="HelpAbout"/>
-    </menu>
-  </menubar>
- 
-  <accelerator name="LookupAccel" action="Lookup"/>
-  <accelerator name="EscapeAccel" action="Escape"/>
-  <accelerator name="SlashAccel" action="Slash"/>
-</ui>
+<interface>
+  <object class="GtkImage" id="menu_icon_new">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon-name">document-new</property>
+  </object>
+  <object class="GtkImage" id="menu_icon_save_as">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon-name">document-save-as</property>
+  </object>
+  <object class="GtkImage" id="menu_icon_print">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon-name">document-print</property>
+  </object>
+  <object class="GtkImage" id="menu_icon_close">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon-name">window-close</property>
+  </object>
+  <object class="GtkImage" id="menu_icon_copy">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon-name">edit-copy</property>
+  </object>
+  <object class="GtkImage" id="menu_icon_find">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon-name">edit-find</property>
+  </object>
+  <object class="GtkImage" id="menu_icon_preferences">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon-name">preferences-desktop</property>
+  </object>
+  <object class="GtkImage" id="menu_icon_previous">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon-name">go-previous</property>
+  </object>
+  <object class="GtkImage" id="menu_icon_next">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon-name">go-next</property>
+  </object>
+  <object class="GtkImage" id="menu_icon_first">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon-name">go-first</property>
+  </object>
+  <object class="GtkImage" id="menu_icon_last">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon-name">go-last</property>
+  </object>
+  <object class="GtkImage" id="menu_icon_help">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon-name">help-browser</property>
+  </object>
+  <object class="GtkImage" id="menu_icon_about">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon-name">help-about</property>
+  </object>
+
+  <object class="GtkMenuBar" id="dictionarymenubar">
+    <property name="visible">1</property>
+    <child internal-child="accessible">
+      <object class="AtkObject" id="a11y-menubar">
+        <property name="AtkObject::accessible-name">The menubar</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem">
+        <property name="visible">1</property>
+        <property name="label" translatable="yes">_File</property>
+        <property name="use-underline">1</property>
+        <child type="submenu">
+          <object class="GtkMenu" id="file_menu">
+            <child>
+              <object class="GtkImageMenuItem" id="new_item">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">_New</property>
+                <property name="tooltip-text" translatable="yes">New look up</property>
+                <property name="use-underline">1</property>
+				/<property name="image">menu_icon_new</property>
+                <property name="action-name">win.FileNew</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkImageMenuItem" id="save_as_item">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">_Save a Copy...</property>
+                <property name="tooltip-text" translatable="yes"></property>
+                <property name="use-underline">1</property>
+                <property name="image">menu_icon_save_as</property>
+                <property name="action-name">win.FileSaveAs</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkSeparatorMenuItem">
+                <property name="visible">1</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkImageMenuItem" id="preview_item">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">P_review...</property>
+                <property name="tooltip-text" translatable="yes">Preview this document</property>
+				<property name="use-underline">1</property>
+                <property name="action-name">win.FilePreview</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkImageMenuItem" id="print_item">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">_Print...</property>
+                <property name="tooltip-text" translatable="yes">Print this document</property>
+                <property name="use-underline">1</property>
+                <property name="image">menu_icon_print</property>
+                <property name="action-name">win.FilePrint</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkSeparatorMenuItem">
+                <property name="visible">1</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkImageMenuItem" id="close_item">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">_Close</property>
+                <property name="tooltip-text" translatable="yes">close the window</property>
+                <property name="use-underline">1</property>
+                <property name="image">menu_icon_close</property>
+                <property name="action-name">win.FileCloseWindow</property>
+              </object>
+	        </child>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem">
+        <property name="visible">1</property>
+        <property name="label" translatable="yes">_Edit</property>
+        <property name="use-underline">1</property>
+        <child type="submenu">
+          <object class="GtkMenu">
+            <child>
+              <object class="GtkImageMenuItem" id="copy_item">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">_Copy</property>
+                <property name="tooltip-text" translatable="yes">Copy the selection</property>
+                <property name="use-underline">1</property>
+                <property name="image">menu_icon_copy</property>
+                <property name="action-name">win.EditCopy</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkSeparatorMenuItem">
+                <property name="visible">1</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkMenuItem" id="select_item">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">Select _All</property>
+                <property name="tooltip-text" translatable="yes"></property>
+                <property name="use-underline">1</property>
+                <property name="action-name">win.EditSelectAll</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkSeparatorMenuItem">
+                <property name="visible">1</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkImageMenuItem" id="find_item">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">_Find</property>
+                <property name="tooltip-text" translatable="yes">Find a word or phrase in the document</property>
+                <property name="use-underline">1</property>
+                <property name="image">menu_icon_find</property>
+                <property name="action-name">win.EditFind</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkMenuItem" id="find_next_item">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">Find Ne_xt</property>
+                <property name="tooltip-text" translatable="yes"></property>
+                <property name="use-underline">1</property>
+                <property name="action-name">win.EditFindNext</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkMenuItem" id="find_previous_item">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">Find Pre_vious</property>
+                <property name="tooltip-text" translatable="yes"></property>
+                <property name="use-underline">1</property>
+                <property name="action-name">win.EditFindPrevious</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkSeparatorMenuItem">
+                <property name="visible">1</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkImageMenuItem" id="preferences_item">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">_Preferences</property>
+                <property name="tooltip-text" translatable="yes"></property>
+                <property name="use-underline">1</property>
+                <property name="image">menu_icon_preferences</property>
+                <property name="action-name">win.EditPreferences</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem">
+        <property name="visible">1</property>
+        <property name="label" translatable="yes">_View</property>
+        <property name="use-underline">1</property>
+        <child type="submenu">
+          <object class="GtkMenu">
+            <child>
+              <object class="GtkCheckMenuItem" id="side_item">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">_Sidebar</property>
+                <property name="tooltip-text" translatable="yes">Show Side Pane</property>
+                <property name="use-underline">1</property>
+                <property name="action-name">win.ViewSidebar</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkCheckMenuItem" id="status_item">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">S_tatusbar</property>
+                <property name="tooltip-text" translatable="yes">Show Status Bar</property>
+                <property name="use-underline">1</property>
+                <property name="action-name">win.ViewStatusbar</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkSeparatorMenuItem">
+                <property name="visible">1</property>
+                <property name="use_action_appearance">0</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkMenuItem" id="speller_item">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">Similar _Words</property>
+                <property name="tooltip-text" translatable="yes"></property>
+                <property name="use-underline">1</property>
+                <property name="action-name">win.ViewSpeller</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkMenuItem" id="sources_item">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">Dictionary Sources</property>
+                <property name="tooltip-text" translatable="yes"></property>
+                <property name="use-underline">1</property>
+                <property name="action-name">win.ViewSource</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkMenuItem" id="db_item">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">Available _Databases</property>
+                <property name="tooltip-text" translatable="yes"></property>
+                <property name="use-underline">1</property>
+                <property name="action-name">win.ViewDB</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkMenuItem" id="strategies_item">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">Available St_rategies</property>
+                <property name="tooltip-text" translatable="yes"></property>
+                <property name="use-underline">1</property>
+                <property name="action-name">win.ViewStrat</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="go_menu">
+        <property name="visible">1</property>
+        <property name="label" translatable="yes">_Go</property>
+        <property name="use-underline">1</property>
+        <child type="submenu">
+          <object class="GtkMenu">
+            <child>
+              <object class="GtkImageMenuItem" id="go_up_item">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">_Previous Definition</property>
+                <property name="tooltip-text" translatable="yes">Go to the previous definition</property>
+                <property name="use-underline">1</property>
+                <property name="image">menu_icon_previous</property>
+                <property name="action-name">win.GoPreviousDef</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkImageMenuItem" id="go_down_item">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">_Next Definition</property>
+                <property name="tooltip-text" translatable="yes">Go to the next definition</property>
+                <property name="use-underline">1</property>
+                <property name="image">menu_icon_next</property>
+                <property name="action-name">win.GoNextDef</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkSeparatorMenuItem">
+                <property name="visible">1</property>
+                <property name="use_action_appearance">0</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkImageMenuItem" id="go_home_item">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">_First Definition</property>
+                <property name="tooltip-text" translatable="yes">Go to the first definition</property>
+                <property name="use-underline">1</property>
+                <property name="image">menu_icon_first</property>
+                <property name="action-name">win.GoFirstDef</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkImageMenuItem" id="go_end_item">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">_Last Definition</property>
+                <property name="tooltip-text" translatable="yes">Go to the last definition</property>
+                <property name="use-underline">1</property>
+                <property name="image">menu_icon_last</property>
+                <property name="action-name">win.GoLastDef</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem">
+        <property name="visible">1</property>
+        <property name="label" translatable="yes">_Help</property>
+        <property name="use-underline">1</property>
+        <child type="submenu">
+          <object class="GtkMenu">
+            <child>
+              <object class="GtkImageMenuItem" id="help_item">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">_Contents</property>
+                <property name="tooltip-text" translatable="yes">Open the help contents for the dictionary</property>
+                <property name="use-underline">1</property>
+                <property name="image">menu_icon_help</property>
+                <property name="action-name">win.HelpContents</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkImageMenuItem" id="about_item">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">_About</property>
+                <property name="tooltip-text" translatable="yes">Show the about dialog for the dictionary</property>
+                <property name="use-underline">1</property>
+                <property name="image">menu_icon_about</property>
+                <property name="action-name">win.HelpAbout</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+	</child>
+  </object>
+</interface>

--- a/mate-dictionary/src/gdict-window.c
+++ b/mate-dictionary/src/gdict-window.c
@@ -191,10 +191,10 @@ gdict_window_dispose (GObject *gobject)
 }
 
 static const gchar *toggle_state[] = {
-  "/MainMenu/FileMenu/SaveAsMenu",
-  "/MainMenu/FileMenu/FilePreviewMenu",
-  "/MainMenu/FileMenu/FilePrintMenu",
-  "/MainMenu/GoMenu",
+  "save_as_item",
+  "preview_item",
+  "print_item",
+  "go_menu",
 };
 
 static gint n_toggle_state = G_N_ELEMENTS (toggle_state);
@@ -215,7 +215,7 @@ gdict_window_ensure_menu_state (GdictWindow *window)
     {
       GtkWidget *item;
 
-      item = gtk_ui_manager_get_widget (window->ui_manager, toggle_state[i]);
+      item = (GtkWidget *)gtk_builder_get_object (window->ui_manager, toggle_state[i]);
       if (!item)
         continue;
 
@@ -233,7 +233,7 @@ gdict_window_set_sidebar_visible (GdictWindow *window,
 
   if (is_visible != window->sidebar_visible)
     {
-      GtkAction *action;
+      GAction *action;
 
       window->sidebar_visible = (is_visible != FALSE);
 
@@ -242,8 +242,8 @@ gdict_window_set_sidebar_visible (GdictWindow *window,
       else
 	gtk_widget_hide (window->sidebar_frame);
 
-      action = gtk_action_group_get_action (window->action_group, "ViewSidebar");
-      gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action), window->sidebar_visible);
+      action = g_action_map_lookup_action (G_ACTION_MAP (window->action_group), "ViewSidebar");
+      g_simple_action_set_state (G_SIMPLE_ACTION (action), g_variant_new_boolean (window->sidebar_visible));
     }
 }
 
@@ -896,9 +896,11 @@ gdict_window_load_state (GdictWindow *window)
 }
 
 static void
-gdict_window_cmd_file_new (GtkAction   *action,
-			   GdictWindow *window)
+gdict_window_cmd_file_new (GSimpleAction *action,
+                           GVariant      *parameter,
+                           gpointer       user_data)
 {
+  GdictWindow *window = user_data;
   GtkWidget *new_window;
   gchar *word = NULL;
 
@@ -923,9 +925,11 @@ gdict_window_cmd_file_new (GtkAction   *action,
 }
 
 static void
-gdict_window_cmd_save_as (GtkAction   *action,
-			  GdictWindow *window)
+gdict_window_cmd_save_as (GSimpleAction *action,
+                          GVariant      *parameter,
+                          gpointer       user_data)
 {
+  GdictWindow *window = user_data;
   GtkWidget *dialog;
 
   g_assert (GDICT_IS_WINDOW (window));
@@ -978,9 +982,11 @@ gdict_window_cmd_save_as (GtkAction   *action,
 }
 
 static void
-gdict_window_cmd_file_preview (GtkAction   *action,
-                               GdictWindow *window)
+gdict_window_cmd_file_preview (GSimpleAction *action,
+                               GVariant      *parameter,
+                               gpointer       user_data)
 {
+  GdictWindow *window = user_data;
   g_assert (GDICT_IS_WINDOW (window));
 
   gdict_show_print_preview (GTK_WINDOW (window),
@@ -988,9 +994,11 @@ gdict_window_cmd_file_preview (GtkAction   *action,
 }
 
 static void
-gdict_window_cmd_file_print (GtkAction   *action,
-			     GdictWindow *window)
+gdict_window_cmd_file_print (GSimpleAction *action,
+                             GVariant      *parameter,
+                             gpointer       user_data)
 {
+  GdictWindow *window = user_data;
   g_assert (GDICT_IS_WINDOW (window));
 
   gdict_show_print_dialog (GTK_WINDOW (window),
@@ -998,9 +1006,11 @@ gdict_window_cmd_file_print (GtkAction   *action,
 }
 
 static void
-gdict_window_cmd_file_close_window (GtkAction   *action,
-				    GdictWindow *window)
+gdict_window_cmd_file_close_window (GSimpleAction *action,
+                                    GVariant      *parameter,
+                                    gpointer       user_data)
 {
+  GdictWindow *window = user_data;
   g_assert (GDICT_IS_WINDOW (window));
 
   gdict_window_store_state (window);
@@ -1014,9 +1024,11 @@ gdict_window_cmd_file_close_window (GtkAction   *action,
 }
 
 static void
-gdict_window_cmd_edit_copy (GtkAction   *action,
-			    GdictWindow *window)
+gdict_window_cmd_edit_copy (GSimpleAction *action,
+                            GVariant      *parameter,
+                            gpointer       user_data)
 {
+  GdictWindow *window = user_data;
   g_assert (GDICT_IS_WINDOW (window));
 
   if (gtk_widget_has_focus (window->entry))
@@ -1027,9 +1039,11 @@ gdict_window_cmd_edit_copy (GtkAction   *action,
 }
 
 static void
-gdict_window_cmd_edit_select_all (GtkAction   *action,
-				  GdictWindow *window)
+gdict_window_cmd_edit_select_all (GSimpleAction *action,
+                                  GVariant      *parameter,
+                                  gpointer       user_data)
 {
+  GdictWindow *window = user_data;
   g_assert (GDICT_IS_WINDOW (window));
 
   if (gtk_widget_has_focus (window->entry))
@@ -1039,36 +1053,43 @@ gdict_window_cmd_edit_select_all (GtkAction   *action,
 }
 
 static void
-gdict_window_cmd_edit_find (GtkAction   *action,
-			    GdictWindow *window)
+gdict_window_cmd_edit_find (GSimpleAction *action,
+                            GVariant      *parameter,
+                            gpointer       user_data)
 {
+  GdictWindow *window = user_data;
   g_assert (GDICT_IS_WINDOW (window));
-
   gdict_defbox_set_show_find (GDICT_DEFBOX (window->defbox), TRUE);
 }
 
 static void
-gdict_window_cmd_edit_find_next (GtkAction   *action,
-				 GdictWindow *window)
+gdict_window_cmd_edit_find_next (GSimpleAction *action,
+                                 GVariant      *parameter,
+                                 gpointer       user_data)
 {
+  GdictWindow *window = user_data;
   g_assert (GDICT_IS_WINDOW (window));
 
   gdict_defbox_find_next (GDICT_DEFBOX (window->defbox));
 }
 
 static void
-gdict_window_cmd_edit_find_previous (GtkAction   *action,
-				     GdictWindow *window)
+gdict_window_cmd_edit_find_previous (GSimpleAction *action,
+                                     GVariant      *parameter,
+                                     gpointer       user_data)
 {
+  GdictWindow *window = user_data;
   g_assert (GDICT_IS_WINDOW (window));
 
   gdict_defbox_find_previous (GDICT_DEFBOX (window->defbox));
 }
 
 static void
-gdict_window_cmd_edit_preferences (GtkAction   *action,
-				   GdictWindow *window)
+gdict_window_cmd_edit_preferences (GSimpleAction *action,
+                                   GVariant      *parameter,
+                                   gpointer       user_data)
 {
+  GdictWindow *window = user_data;
   g_assert (GDICT_IS_WINDOW (window));
 
   gdict_show_pref_dialog (GTK_WIDGET (window),
@@ -1077,12 +1098,40 @@ gdict_window_cmd_edit_preferences (GtkAction   *action,
 }
 
 static void
-gdict_window_cmd_view_sidebar (GtkToggleAction *action,
-			       GdictWindow     *window)
+sidebar_activate_toggle (GSimpleAction *action,
+                         GVariant      *parameter,
+                         gpointer       user_data)
 {
+  GVariant *state;
+
+  state = g_action_get_state (G_ACTION (action));
+  g_action_change_state (G_ACTION (action), g_variant_new_boolean (!g_variant_get_boolean (state)));
+  g_variant_unref (state);
+}
+
+static void
+statusbar_activate_toggle (GSimpleAction *action,
+                           GVariant      *parameter,
+                           gpointer       user_data)
+{
+  GVariant *state;
+
+  state = g_action_get_state (G_ACTION (action));
+  g_action_change_state (G_ACTION (action), g_variant_new_boolean (!g_variant_get_boolean (state)));
+  g_variant_unref (state);
+}
+
+static void
+gdict_window_cmd_view_sidebar (GSimpleAction *action,
+                               GVariant      *state,
+                               gpointer       user_data)
+{
+  GdictWindow *window = user_data;
   g_assert (GDICT_IS_WINDOW (window));
 
-  window->sidebar_visible = (gtk_toggle_action_get_active (action) != FALSE);
+  g_variant_get_boolean (state);
+  window->sidebar_visible = (g_variant_get_boolean (state) != FALSE);
+  g_simple_action_set_state (action, state);
 
   if (window->sidebar_visible)
     gtk_widget_show (window->sidebar_frame);
@@ -1091,12 +1140,15 @@ gdict_window_cmd_view_sidebar (GtkToggleAction *action,
 }
 
 static void
-gdict_window_cmd_view_statusbar (GtkToggleAction *action,
-				 GdictWindow     *window)
+gdict_window_cmd_view_statusbar (GSimpleAction *action,
+                                 GVariant      *state,
+                                 gpointer       user_data)
 {
+  GdictWindow *window = user_data;
   g_assert (GDICT_IS_WINDOW (window));
 
-  window->statusbar_visible = (gtk_toggle_action_get_active (action) != FALSE);
+  window->statusbar_visible = (g_variant_get_boolean (state) != FALSE);
+  g_simple_action_set_state (action, state);
 
   if (window->statusbar_visible)
     gtk_widget_show (window->status);
@@ -1106,9 +1158,12 @@ gdict_window_cmd_view_statusbar (GtkToggleAction *action,
 }
 
 static void
-gdict_window_cmd_view_speller (GtkAction   *action,
-			       GdictWindow *window)
+gdict_window_cmd_view_speller (GSimpleAction *action,
+                               GVariant      *parameter,
+                               gpointer       user_data)
+
 {
+  GdictWindow *window = user_data;
   g_assert (GDICT_IS_WINDOW (window));
 
   gdict_sidebar_view_page (GDICT_SIDEBAR (window->sidebar),
@@ -1117,9 +1172,12 @@ gdict_window_cmd_view_speller (GtkAction   *action,
 }
 
 static void
-gdict_window_cmd_view_databases (GtkAction   *action,
-				 GdictWindow *window)
+gdict_window_cmd_view_databases (GSimpleAction *action,
+                                 GVariant      *parameter,
+                                 gpointer       user_data)
+
 {
+  GdictWindow *window = user_data;
   g_assert (GDICT_IS_WINDOW (window));
 
   gdict_sidebar_view_page (GDICT_SIDEBAR (window->sidebar),
@@ -1128,9 +1186,12 @@ gdict_window_cmd_view_databases (GtkAction   *action,
 }
 
 static void
-gdict_window_cmd_view_strategies (GtkAction   *action,
-                                  GdictWindow *window)
+gdict_window_cmd_view_strategies (GSimpleAction *action,
+                                  GVariant      *parameter,
+                                  gpointer       user_data)
+
 {
+  GdictWindow *window = user_data;
   g_assert (GDICT_IS_WINDOW (window));
 
   gdict_sidebar_view_page (GDICT_SIDEBAR (window->sidebar),
@@ -1139,9 +1200,12 @@ gdict_window_cmd_view_strategies (GtkAction   *action,
 }
 
 static void
-gdict_window_cmd_view_sources (GtkAction   *action,
-                               GdictWindow *window)
+gdict_window_cmd_view_sources (GSimpleAction *action,
+                               GVariant      *parameter,
+                               gpointer       user_data)
+
 {
+  GdictWindow *window = user_data;
   g_assert (GDICT_IS_WINDOW (window));
 
   gdict_sidebar_view_page (GDICT_SIDEBAR (window->sidebar),
@@ -1150,9 +1214,11 @@ gdict_window_cmd_view_sources (GtkAction   *action,
 }
 
 static void
-gdict_window_cmd_go_first_def (GtkAction   *action,
-			       GdictWindow *window)
+gdict_window_cmd_go_first_def (GSimpleAction *action,
+                               GVariant      *parameter,
+                               gpointer       user_data)
 {
+  GdictWindow *window = user_data;
   g_assert (GDICT_IS_WINDOW (window));
 
   window->last_definition = 0;
@@ -1161,9 +1227,11 @@ gdict_window_cmd_go_first_def (GtkAction   *action,
 }
 
 static void
-gdict_window_cmd_go_previous_def (GtkAction   *action,
-				  GdictWindow *window)
+gdict_window_cmd_go_previous_def (GSimpleAction *action,
+                                  GVariant      *parameter,
+                                  gpointer       user_data)
 {
+  GdictWindow *window = user_data;
   g_assert (GDICT_IS_WINDOW (window));
 
   if (window->last_definition == 0)
@@ -1175,9 +1243,11 @@ gdict_window_cmd_go_previous_def (GtkAction   *action,
 }
 
 static void
-gdict_window_cmd_go_next_def (GtkAction   *action,
-			      GdictWindow *window)
+gdict_window_cmd_go_next_def (GSimpleAction *action,
+                              GVariant      *parameter,
+                              gpointer       user_data)
 {
+  GdictWindow *window = user_data;
   g_assert (GDICT_IS_WINDOW (window));
 
   if (window->max_definition == -1)
@@ -1192,9 +1262,11 @@ gdict_window_cmd_go_next_def (GtkAction   *action,
 }
 
 static void
-gdict_window_cmd_go_last_def (GtkAction   *action,
-			      GdictWindow *window)
+gdict_window_cmd_go_last_def (GSimpleAction *action,
+                              GVariant      *parameter,
+                              gpointer       user_data)
 {
+  GdictWindow *window = user_data;
   g_assert (GDICT_IS_WINDOW (window));
 
   if (window->max_definition == -1)
@@ -1206,9 +1278,12 @@ gdict_window_cmd_go_last_def (GtkAction   *action,
 }
 
 static void
-gdict_window_cmd_help_contents (GtkAction   *action,
-				GdictWindow *window)
+gdict_window_cmd_help_contents (GSimpleAction *action,
+                                GVariant      *parameter,
+                                gpointer       user_data)
+
 {
+  GdictWindow *window = user_data;
   GError *err = NULL;
 
   g_return_if_fail (GDICT_IS_WINDOW (window));
@@ -1225,105 +1300,106 @@ gdict_window_cmd_help_contents (GtkAction   *action,
 }
 
 static void
-gdict_window_cmd_help_about (GtkAction   *action,
-			     GdictWindow *window)
+gdict_window_cmd_help_about (GSimpleAction *action,
+                             GVariant      *parameter,
+                             gpointer       user_data)
+
 {
+  GdictWindow *window = user_data;
   g_assert (GDICT_IS_WINDOW (window));
 
   gdict_show_about_dialog (GTK_WIDGET (window));
 }
 
 static void
-gdict_window_cmd_lookup (GtkAction   *action,
-			 GdictWindow *window)
+gdict_window_cmd_lookup (gpointer user_data)
+
 {
+  GdictWindow *window = user_data;
   g_assert (GDICT_IS_WINDOW (window));
 
   gtk_widget_grab_focus (window->entry);
 }
 
 static void
-gdict_window_cmd_escape (GtkAction   *action,
-			 GdictWindow *window)
+gdict_window_cmd_escape (gpointer user_data)
+
 {
+  GdictWindow *window = user_data;
   g_assert (GDICT_IS_WINDOW (window));
 
   gdict_defbox_set_show_find (GDICT_DEFBOX (window->defbox), FALSE);
 }
 
-static const GtkActionEntry entries[] =
+static void
+gdict_window_cmd_slash (gpointer user_data)
 {
-  { "File", NULL, N_("_File"), NULL, NULL, NULL },
-  { "Edit", NULL, N_("_Edit"), NULL, NULL, NULL },
-  { "View", NULL, N_("_View"), NULL, NULL, NULL },
-  { "Go",   NULL, N_("_Go"),   NULL, NULL, NULL },
-  { "Help", NULL, N_("_Help"), NULL, NULL, NULL },
+  GdictWindow *window = user_data;
+  g_assert (GDICT_IS_WINDOW (window));
 
+  gdict_defbox_set_show_find (GDICT_DEFBOX (window->defbox), TRUE);
+}
+
+static const GActionEntry entries[] =
+{
   /* File menu */
-  { "FileNew", "document-new", N_("_New"), "<control>N",
-    N_("New look up"), G_CALLBACK (gdict_window_cmd_file_new) },
-  { "FileSaveAs", "document-save-as", N_("_Save a Copy..."), NULL, NULL,
-    G_CALLBACK (gdict_window_cmd_save_as) },
-  { "FilePreview", NULL, N_("P_review..."), "<control><shift>P",
-    N_("Preview this document"), G_CALLBACK (gdict_window_cmd_file_preview) },
-  { "FilePrint", "document-print", N_("_Print..."), "<control>P",
-    N_("Print this document"), G_CALLBACK (gdict_window_cmd_file_print) },
-  { "FileCloseWindow", "window-close", N_("_Close"), "<control>W", NULL,
-    G_CALLBACK (gdict_window_cmd_file_close_window) },
+  { "FileNew",     gdict_window_cmd_file_new, NULL, NULL, NULL },
+  { "FileSaveAs",  gdict_window_cmd_save_as, NULL, NULL, NULL },
+  { "FilePreview", gdict_window_cmd_file_preview, NULL, NULL, NULL },
+  { "FilePrint",   gdict_window_cmd_file_print, NULL, NULL, NULL },
+  { "FileCloseWindow", gdict_window_cmd_file_close_window, NULL, NULL, NULL },
 
   /* Edit menu */
-  { "EditCopy", "edit-copy", N_("_Copy"), "<control>C", NULL,
-    G_CALLBACK (gdict_window_cmd_edit_copy) },
-  { "EditSelectAll", NULL, N_("Select _All"), "<control>A", NULL,
-    G_CALLBACK (gdict_window_cmd_edit_select_all) },
-  { "EditFind", "edit-find", N_("_Find"), "<control>F",
-    N_("Find a word or phrase in the document"),
-    G_CALLBACK (gdict_window_cmd_edit_find) },
-  { "EditFindNext", NULL, N_("Find Ne_xt"), "<control>G", NULL,
-    G_CALLBACK (gdict_window_cmd_edit_find_next) },
-  { "EditFindPrevious", NULL, N_("Find Pre_vious"), "<control><shift>G", NULL,
-    G_CALLBACK (gdict_window_cmd_edit_find_previous) },
-  { "EditPreferences", "preferences-desktop", N_("_Preferences"), NULL, NULL,
-    G_CALLBACK (gdict_window_cmd_edit_preferences) },
+  { "EditCopy",      gdict_window_cmd_edit_copy, NULL, NULL, NULL },
+  { "EditSelectAll", gdict_window_cmd_edit_select_all, NULL, NULL, NULL },
+  { "EditFind",      gdict_window_cmd_edit_find, NULL, NULL, NULL },
+  { "EditFindNext",  gdict_window_cmd_edit_find_next, NULL, NULL, NULL },
+  { "EditFindPrevious", gdict_window_cmd_edit_find_previous, NULL, NULL, NULL },
+  { "EditPreferences", gdict_window_cmd_edit_preferences, NULL, NULL, NULL },
 
   /* Go menu */
-  { "GoPreviousDef", "go-previous", N_("_Previous Definition"), "<control>Page_Up",
-    N_("Go to the previous definition"), G_CALLBACK (gdict_window_cmd_go_previous_def) },
-  { "GoNextDef", "go-next", N_("_Next Definition"), "<control>Page_Down",
-    N_("Go to the next definition"), G_CALLBACK (gdict_window_cmd_go_next_def) },
-  { "GoFirstDef", "go-first", N_("_First Definition"), "<control>Home",
-    N_("Go to the first definition"), G_CALLBACK (gdict_window_cmd_go_first_def) },
-  { "GoLastDef", "go-last", N_("_Last Definition"), "<control>End",
-    N_("Go to the last definition"), G_CALLBACK (gdict_window_cmd_go_last_def) },
+  { "GoPreviousDef", gdict_window_cmd_go_previous_def, NULL, NULL, NULL },
+  { "GoNextDef",  gdict_window_cmd_go_next_def, NULL, NULL, NULL },
+  { "GoFirstDef", gdict_window_cmd_go_first_def, NULL, NULL, NULL },
+  { "GoLastDef",  gdict_window_cmd_go_last_def, NULL, NULL, NULL },
 
   /* View menu */
-  { "ViewSpeller", NULL, N_("Similar _Words"), "<control>T", NULL,
-    G_CALLBACK (gdict_window_cmd_view_speller), },
-  { "ViewSource", NULL, N_("Dictionary Sources"), "<control>D", NULL,
-    G_CALLBACK (gdict_window_cmd_view_sources), },
-  { "ViewDB", NULL, N_("Available _Databases"), "<control>B", NULL,
-    G_CALLBACK (gdict_window_cmd_view_databases), },
-  { "ViewStrat", NULL, N_("Available St_rategies"), "<control>R", NULL,
-    G_CALLBACK (gdict_window_cmd_view_strategies), },
+  { "ViewSidebar",   sidebar_activate_toggle, NULL, "false", gdict_window_cmd_view_sidebar },
+  { "ViewStatusbar", statusbar_activate_toggle, NULL, "false", gdict_window_cmd_view_statusbar },
+  { "ViewSpeller", gdict_window_cmd_view_speller, NULL, NULL, NULL },
+  { "ViewSource", gdict_window_cmd_view_sources, NULL, NULL, NULL },
+  { "ViewDB", gdict_window_cmd_view_databases, NULL, NULL, NULL },
+  { "ViewStrat", gdict_window_cmd_view_strategies, NULL, NULL, NULL },
 
   /* Help menu */
-  { "HelpContents", "help-browser", N_("_Contents"), "F1", NULL,
-    G_CALLBACK (gdict_window_cmd_help_contents) },
-  { "HelpAbout", "help-about", N_("_About"), NULL, NULL,
-    G_CALLBACK (gdict_window_cmd_help_about) },
-
-  /* Accelerators */
-  { "Lookup", NULL, "", "<control>L", NULL, G_CALLBACK (gdict_window_cmd_lookup) },
-  { "Escape", NULL, "", "Escape", "", G_CALLBACK (gdict_window_cmd_escape) },
-  { "Slash", "edit-find", NULL, "slash", NULL, G_CALLBACK (gdict_window_cmd_edit_find) },
+  { "HelpContents", gdict_window_cmd_help_contents, NULL, NULL, NULL },
+  { "HelpAbout", gdict_window_cmd_help_about, NULL, NULL, NULL },
 };
 
-static const GtkToggleActionEntry toggle_entries[] = {
-  /* View menu */
-  { "ViewSidebar", NULL, N_("_Sidebar"), "F9", NULL,
-    G_CALLBACK (gdict_window_cmd_view_sidebar), FALSE },
-  { "ViewStatusbar", NULL, N_("S_tatusbar"), NULL, NULL,
-    G_CALLBACK (gdict_window_cmd_view_statusbar), FALSE },
+static const struct {
+  guint keyval;
+  GdkModifierType modifier;
+  const gchar *widget_id;
+} menu_keybindings [] = {
+  { GDK_KEY_N,      GDK_CONTROL_MASK, "new_item" },
+  { GDK_KEY_S,      GDK_SHIFT_MASK | GDK_CONTROL_MASK, "preview_item" },
+  { GDK_KEY_P,      GDK_CONTROL_MASK, "print_item" },
+  { GDK_KEY_W,      GDK_CONTROL_MASK, "close_item" },
+  { GDK_KEY_C,      GDK_CONTROL_MASK, "copy_item" },
+  { GDK_KEY_A,      GDK_CONTROL_MASK, "select_item" },
+  { GDK_KEY_F,      GDK_CONTROL_MASK, "find_item" },
+  { GDK_KEY_G,      GDK_CONTROL_MASK, "find_next_item" },
+  { GDK_KEY_G,      GDK_SHIFT_MASK | GDK_CONTROL_MASK, "find_previous_item" },
+  { GDK_KEY_Page_Up,   GDK_CONTROL_MASK, "go_up_item" },
+  { GDK_KEY_Page_Down, GDK_CONTROL_MASK, "go_down_item" },
+  { GDK_KEY_Home,      GDK_CONTROL_MASK, "go_home_item" },
+  { GDK_KEY_End,       GDK_CONTROL_MASK, "go_end_item" },
+  { GDK_KEY_F9,     0, "side_item" },
+  { GDK_KEY_T,      GDK_CONTROL_MASK, "speller_item" },
+  { GDK_KEY_D,      GDK_CONTROL_MASK, "sources_item" },
+  { GDK_KEY_B,      GDK_CONTROL_MASK, "db_item" },
+  { GDK_KEY_R,      GDK_CONTROL_MASK, "strategies_item" },
+  { GDK_KEY_F1,     0, "help_item" }
 };
 
 static gboolean
@@ -1331,7 +1407,7 @@ gdict_window_delete_event_cb (GtkWidget *widget,
 			      GdkEvent  *event,
 			      gpointer   user_data)
 {
-  gdict_window_cmd_file_close_window (NULL, GDICT_WINDOW (widget));
+  gdict_window_cmd_file_close_window (NULL, NULL, GDICT_WINDOW (widget));
 
   return FALSE;
 }
@@ -1602,12 +1678,15 @@ gdict_window_constructor (GType                  type,
   GtkWidget *frame1, *frame2;
   GtkWidget *vbox;
   GtkWidget *button;
-  GtkActionGroup *action_group;
+  GtkWidget *item;
+  GActionGroup *action_group;
   GtkAccelGroup *accel_group;
   PangoFontDescription *font_desc;
   gchar *font_name;
   GError *error;
   GtkAllocation allocation;
+  GClosure *lookup, *escape, *slash;
+  int i;
 
   object = G_OBJECT_CLASS (gdict_window_parent_class)->constructor (type, n_construct_properties, construct_params);
   window = GDICT_WINDOW (object);
@@ -1622,24 +1701,20 @@ gdict_window_constructor (GType                  type,
   gtk_widget_show (window->main_box);
 
   /* build menus */
-  action_group = gtk_action_group_new ("MenuActions");
+  action_group = (GActionGroup*)g_simple_action_group_new ();
   window->action_group = action_group;
-  gtk_action_group_set_translation_domain (action_group, NULL);
-  gtk_action_group_add_actions (action_group, entries,
-  				G_N_ELEMENTS (entries),
-  				window);
-  gtk_action_group_add_toggle_actions (action_group, toggle_entries,
-                                       G_N_ELEMENTS (toggle_entries),
-                                       window);
+  g_action_map_add_action_entries (G_ACTION_MAP (action_group),
+                                   entries, G_N_ELEMENTS (entries),
+                                   window);
 
-  window->ui_manager = gtk_ui_manager_new ();
-  gtk_ui_manager_insert_action_group (window->ui_manager, action_group, 0);
+  window->ui_manager = gtk_builder_new ();
+  gtk_widget_insert_action_group (GTK_WIDGET (window), "win", action_group);
 
-  accel_group = gtk_ui_manager_get_accel_group (window->ui_manager);
+  accel_group = gtk_accel_group_new ();
   gtk_window_add_accel_group (GTK_WINDOW (window), accel_group);
 
   error = NULL;
-  if (!gtk_ui_manager_add_ui_from_file (window->ui_manager,
+  if (!gtk_builder_add_from_file (window->ui_manager,
   					PKGDATADIR "/mate-dictionary-ui.xml",
   					&error))
     {
@@ -1648,13 +1723,30 @@ gdict_window_constructor (GType                  type,
     }
   else
     {
-      window->menubar = gtk_ui_manager_get_widget (window->ui_manager, "/MainMenu");
+      window->menubar = (GtkWidget *)gtk_builder_get_object (window->ui_manager, "dictionarymenubar");
 
       gtk_box_pack_start (GTK_BOX (window->main_box), window->menubar, FALSE, FALSE, 0);
       gtk_widget_show (window->menubar);
 
       gdict_window_ensure_menu_state (window);
     }
+
+  for (i = 0; i < G_N_ELEMENTS (menu_keybindings); i++)
+  {
+    item = (GtkWidget*)gtk_builder_get_object (window->ui_manager, menu_keybindings[i].widget_id);
+    gtk_widget_add_accelerator (item, "activate", accel_group,
+                                menu_keybindings[i].keyval,
+                                menu_keybindings[i].modifier,
+                                GTK_ACCEL_VISIBLE);
+  }
+  lookup = g_cclosure_new_swap (G_CALLBACK (gdict_window_cmd_lookup), window, NULL);
+  gtk_accel_group_connect (accel_group, GDK_KEY_L, GDK_CONTROL_MASK, 0, lookup);
+
+  escape = g_cclosure_new_swap (G_CALLBACK (gdict_window_cmd_escape), window, NULL);
+  gtk_accel_group_connect (accel_group, GDK_KEY_Escape, 0, 0, escape);
+
+  slash = g_cclosure_new_swap (G_CALLBACK (gdict_window_cmd_slash), window, NULL);
+  gtk_accel_group_connect (accel_group, GDK_KEY_slash, 0, 0, slash);
 
   vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
   gtk_container_set_border_width (GTK_CONTAINER (vbox), 6);
@@ -1808,10 +1900,10 @@ gdict_window_constructor (GType                  type,
 
   if (window->sidebar_visible)
     {
-      GtkAction *action;
+      GAction *action;
 
-      action = gtk_action_group_get_action (window->action_group, "ViewSidebar");
-      gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action), TRUE);
+      action = g_action_map_lookup_action (G_ACTION_MAP (window->action_group), "ViewSidebar");
+      g_simple_action_set_state (G_SIMPLE_ACTION (action), g_variant_new_boolean (TRUE));
       gtk_widget_show (window->sidebar_frame);
     }
 
@@ -1819,10 +1911,10 @@ gdict_window_constructor (GType                  type,
   gtk_box_pack_end (GTK_BOX (window->main_box), window->status, FALSE, FALSE, 0);
   if (window->statusbar_visible)
     {
-      GtkAction *action;
+      GAction *action;
 
-      action = gtk_action_group_get_action (window->action_group, "ViewStatusbar");
-      gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action), TRUE);
+      action = g_action_map_lookup_action (G_ACTION_MAP (window->action_group), "ViewStatusbar");
+      g_simple_action_set_state (G_SIMPLE_ACTION (action), g_variant_new_boolean (TRUE));
       gtk_widget_show (window->status);
     }
 
@@ -2035,10 +2127,10 @@ gdict_window_new (GdictWindowAction  action,
   g_return_val_if_fail (GDICT_IS_SOURCE_LOADER (loader), NULL);
 
   retval = g_object_new (GDICT_TYPE_WINDOW,
-  			 "action", action,
+                         "action", action,
                          "source-loader", loader,
-			 "source-name", source_name,
-			 NULL);
+                         "source-name", source_name,
+                         NULL);
 
   window = GDICT_WINDOW (retval);
 

--- a/mate-dictionary/src/gdict-window.h
+++ b/mate-dictionary/src/gdict-window.h
@@ -66,8 +66,8 @@ struct _GdictWindow
   GtkWidget *status;
   GtkWidget *progress;
 
-  GtkUIManager *ui_manager;
-  GtkActionGroup *action_group;
+  GtkBuilder *ui_manager;
+  GActionGroup *action_group;
 
   GtkEntryCompletion *completion;
   GtkListStore *completion_model;


### PR DESCRIPTION
Replace the deprecated API with ```GtkMenuBar``` + ```GActionGroup``` + ```GtkBuilder``` fix compilation warnings
```
gdict-window.c:218:7: warning: 'gtk_ui_manager_get_widget' is deprecated [-Wdeprecated-declarations]
       item = gtk_ui_manager_get_widget (window->ui_manager, toggle_state[i]);

gdict-window.c:218:7: warning: 'gtk_ui_manager_get_widget' is deprecated [-Wdeprecated-declarations]
       item = gtk_ui_manager_get_widget (window->ui_manager, toggle_state[i]);

```

