### PR TITLE
dictionary applet: allow building in-process, fix the popup response dialog

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -206,6 +206,26 @@ AS_CASE([$enable_gdict_applet],
 
 AM_CONDITIONAL([BUILD_GDICT_APPLET], [test "x$enable_gdict_applet" = "xyes"])
 
+AC_ARG_ENABLE([in-process],
+              [AS_HELP_STRING([--enable-in-process],
+                              [Build dictionary applet in-process])],
+              [enable_in_process=$enableval],
+              [enable_in_process=no])
+
+# Automake conditional on whether to build dictionary applet in-process
+AM_CONDITIONAL([ENABLE_IN_PROCESS], [test "x$enable_in_process" = "xyes"])
+AS_IF([test "x$enable_in_process" = "xyes"],
+      [AC_SUBST([APPLET_IN_PROCESS], [true])],
+      [AC_SUBST([APPLET_IN_PROCESS], [false])])
+# C conditional on whether to build in-process
+AS_IF([test "x$enable_in_process" = "xyes"],
+      [AC_DEFINE([ENABLE_IN_PROCESS], [1], [building in-process])])
+# Convenience C define selecting the right applet factory
+AS_IF([test "x$enable_in_process" = "xyes"],
+      [factory=MATE_PANEL_APPLET_IN_PROCESS_FACTORY],
+      [factory=MATE_PANEL_APPLET_OUT_PROCESS_FACTORY])
+AC_DEFINE_UNQUOTED([PANEL_APPLET_FACTORY], [$factory], [Panel applet factory])
+
 # Baobab checks
 PKG_CHECK_MODULES(LIBGTOP, libgtop-2.0 >= $LIBGTOP_REQUIRED)
 AC_SUBST(LIBGTOP_CFLAGS)
@@ -411,5 +431,6 @@ mate-utils $VERSION configuration summary:
       API Reference (libmatedict) : $enable_gtk_doc
   Logview built with ZLib support : $msg_zlib
      Dictionary mate-panel applet : $enable_gdict_applet
+     Dictionary applet in-process : $enable_in_process
           Native Language support : ${USE_NLS}
 "

--- a/mate-dictionary/data/Makefile.am
+++ b/mate-dictionary/data/Makefile.am
@@ -62,9 +62,17 @@ appletdir = $(datadir)/mate-panel/applets
 applet_in_files = org.mate.DictionaryApplet.mate-panel-applet.desktop.in
 applet_DATA = $(applet_in_files:.mate-panel-applet.desktop.in=.mate-panel-applet)
 
+if ENABLE_IN_PROCESS
+APPLET_LOCATION = $(pkglibdir)/libmate-dictionary-applet.so
+APPLET_IN_PROCESS = true
+else
+APPLET_LOCATION = $(libexecdir)/mate-dictionary-applet
+APPLET_IN_PROCESS = false
+endif
 $(applet_in_files): $(applet_in_files).in Makefile
 	$(AM_V_GEN)sed \
-		-e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
+		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+		-e "s|\@APPLET_IN_PROCESS\@|$(APPLET_IN_PROCESS)|" \
 		$< > $@
 
 $(applet_DATA): $(applet_in_files) Makefile
@@ -74,6 +82,7 @@ else
 	$(AM_V_GEN) cp $< $@
 endif
 
+if !ENABLE_IN_PROCESS
 servicedir = $(datadir)/dbus-1/services
 service_in_files = org.mate.panel.applet.DictionaryAppletFactory.service.in
 service_DATA = $(service_in_files:.service.in=.service)
@@ -82,6 +91,7 @@ org.mate.panel.applet.DictionaryAppletFactory.service: $(service_in_files)
 	$(AM_V_GEN)sed \
 		-e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
 		$< > $@
+endif
 
 ui_DATA += dictionary-applet-menu.xml
 

--- a/mate-dictionary/data/org.mate.DictionaryApplet.mate-panel-applet.desktop.in.in
+++ b/mate-dictionary/data/org.mate.DictionaryApplet.mate-panel-applet.desktop.in.in
@@ -1,6 +1,7 @@
 [Applet Factory]
 Id=DictionaryAppletFactory
-Location=@LIBEXECDIR@/mate-dictionary-applet
+Location=@APPLET_LOCATION@
+InProcess=@APPLET_IN_PROCESS@
 Name=Dictionary Applet Factory
 Description=Factory for the dictionary applet
 

--- a/mate-dictionary/src/Makefile.am
+++ b/mate-dictionary/src/Makefile.am
@@ -27,7 +27,11 @@ AM_CPPFLAGS = \
 bin_PROGRAMS = mate-dictionary
 
 if BUILD_GDICT_APPLET
+if ENABLE_IN_PROCESS
+pkglib_LTLIBRARIES = libmate-dictionary-applet.la
+else
 libexec_PROGRAMS = mate-dictionary-applet
+endif
 endif
 
 mate_dictionary_SOURCES = \
@@ -69,6 +73,45 @@ mate_dictionary_LDADD = \
 
 if BUILD_GDICT_APPLET
 
+if ENABLE_IN_PROCESS
+libmate_dictionary_applet_la_SOURCES = \
+	gdict-about.c 		\
+	gdict-about.h		\
+	gdict-aligned-window.c	\
+	gdict-aligned-window.h	\
+	gdict-applet.c		\
+	gdict-applet.h		\
+	gdict-common.c		\
+	gdict-common.h		\
+	gdict-pref-dialog.c	\
+	gdict-pref-dialog.h	\
+	gdict-print.c 		\
+	gdict-print.h 		\
+	gdict-sidebar.c		\
+	gdict-sidebar.h		\
+	gdict-source-dialog.c 	\
+	gdict-source-dialog.h 	\
+	$(NULL)
+
+libmate_dictionary_applet_la_CFLAGS = \
+	-I$(top_builddir)/mate-dictionary \
+	-I$(top_srcdir)/mate-dictionary \
+	$(APPLET_CFLAGS) \
+	$(GLIB_CFLAGS) \
+	$(GIO_CFLAGS) \
+	$(GTK_CFLAGS) \
+	$(WARN_CFLAGS) \
+	$(NULL)
+
+libmate_dictionary_applet_la_LIBADD = \
+	-lm			\
+	$(top_builddir)/mate-dictionary/libgdict/libmatedict.la \
+	$(APPLET_LIBS) \
+	$(GLIB_LIBS) \
+	$(GIO_LIBS) \
+	$(GTK_LIBS) \
+	$(NULL)
+else
 mate_dictionary_applet_SOURCES = \
 	gdict-about.c 		\
 	gdict-about.h		\
@@ -106,7 +149,7 @@ mate_dictionary_applet_LDADD = \
 	$(GIO_LIBS) \
 	$(GTK_LIBS) \
 	$(NULL)
-
+endif # ENABLE_IN_PROCESS
 endif # BUILD_GDICT_APPLET
 
 -include $(top_srcdir)/git.mk

--- a/mate-dictionary/src/gdict-aligned-window.c
+++ b/mate-dictionary/src/gdict-aligned-window.c
@@ -154,8 +154,10 @@ gdict_aligned_window_position (GdictAlignedWindow *window)
   gint entry_x, entry_y, entry_width, entry_height;
   gint x, y;
   GdkGravity gravity = GDK_GRAVITY_NORTH_WEST;
-  GdkWindow *gdk_window;
+  GdkWindow  *gdk_window;
   GdkDisplay *display;
+  GdkMonitor *monitor;
+  GdkRectangle geometry = {0};
 
   g_assert (GDICT_IS_ALIGNED_WINDOW (window));
   priv = window->priv;
@@ -185,7 +187,12 @@ gdict_aligned_window_position (GdictAlignedWindow *window)
   			 &entry_y);
   gdk_window_get_geometry (gdk_window, NULL, NULL, &entry_width, &entry_height);
 
-  if (entry_x + our_width < WidthOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())))
+  /*Get the monitor dimensions*/
+  display= gdk_screen_get_display (gdk_screen_get_default ());
+  monitor = gdk_display_get_monitor (display, 0);
+  gdk_monitor_get_geometry (monitor, &geometry);
+
+  if (entry_x + our_width < geometry.width)
     x = entry_x + 1;
   else
     {
@@ -194,7 +201,7 @@ gdict_aligned_window_position (GdictAlignedWindow *window)
       gravity = GDK_GRAVITY_NORTH_EAST;
     }
 
-  if (entry_y + entry_height + our_height < HeightOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())))
+  if (entry_y + entry_height + our_height < geometry.height)
     y = entry_y + entry_height - 1;
   else
     {

--- a/mate-dictionary/src/gdict-applet.c
+++ b/mate-dictionary/src/gdict-applet.c
@@ -1214,9 +1214,9 @@ gdict_applet_factory (MatePanelApplet *applet,
 }
 
 /* this defines the main () for the applet */
-MATE_PANEL_APPLET_OUT_PROCESS_FACTORY ("DictionaryAppletFactory",
-			     GDICT_TYPE_APPLET,
-			     "mate-dictionary-applet",
-			     gdict_applet_factory,
-			     NULL);
+PANEL_APPLET_FACTORY ("DictionaryAppletFactory",
+		      GDICT_TYPE_APPLET,
+		      "mate-dictionary-applet",
+		      gdict_applet_factory,
+		      NULL);
 


### PR DESCRIPTION
*In-process is needed for wayland support
*this also fixes an unresponsive response dialog out of process
*Depends on https://github.com/mate-desktop/mate-panel/pull/1400 for in-process builds to run

