### PR TITLE
search tool: show also in other desktops

### DIFF
--- a/gsearchtool/data/mate-search-tool.desktop.in
+++ b/gsearchtool/data/mate-search-tool.desktop.in
@@ -10,7 +10,6 @@ StartupNotify=true
 Categories=GTK;Utility;Core;
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 Keywords=MATE;search;files;locate;documents;folders;computer;name;content;find;tool;
-OnlyShowIn=MATE;
 X-MATE-DocPath=mate-search-tool/mate-search-tool.xml
 X-MATE-Bugzilla-Bugzilla=MATE
 X-MATE-Bugzilla-Product=mate-utils


### PR DESCRIPTION
With GNOME search tool being deprecated and removed from some distros therefore, how about making this app available in other desktops too?