### PR TITLE
mate-screenshot: Toggle shutter sound

### DIFF
--- a/mate-screenshot/data/org.mate.screenshot.gschema.xml.in
+++ b/mate-screenshot/data/org.mate.screenshot.gschema.xml.in
@@ -25,5 +25,10 @@
       <summary>Border Effect</summary>
       <description>Effect to add to the outside of a border.  Possible values are "shadow", "none", and "border".</description>
     </key>
+    <key name="enable-sound" type="b">
+      <default>true</default>
+      <summary>Enable sound</summary>
+      <description>Whether to play a sound when taking a screenshot</description>
+    </key>
   </schema>
 </schemalist>

--- a/mate-screenshot/src/mate-screenshot.c
+++ b/mate-screenshot/src/mate-screenshot.c
@@ -55,6 +55,7 @@
 #define LAST_SAVE_DIRECTORY_KEY "last-save-directory"
 #define BORDER_EFFECT_KEY       "border-effect"
 #define DELAY_KEY               "delay"
+#define ENABLE_SOUND_KEY        "enable-sound"
 #define CAJA_PREFERENCES_SCHEMA "org.mate.caja.preferences"
 
 enum
@@ -852,7 +853,8 @@ finish_prepare_screenshot (char *initial_uri, GdkWindow *window, GdkRectangle *r
       exit (1);
     }
 
-  play_sound_effect (window);
+  if (g_settings_get_boolean (settings, ENABLE_SOUND_KEY))
+    play_sound_effect (window);
 
   if (noninteractive_clipboard_arg) {
     save_screenshot_in_clipboard (gdk_window_get_display (window), screenshot);


### PR DESCRIPTION
This setting allows user to enable/disable the shutter sound when taking a screenshot. Default is enabled to maintain current behavior.

Fixes #134