### PR TITLE
Release 1.28.1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+### mate-utils 1.28.1
+
+  * ci: migrate from Travis CI to GitHub Actions
+  * mate-screenshot: Replace fork save with sync save
+  * mate-screenshot: Toggle shutter sound
+
 ### mate-utils 1.28.0
 
   * Translations update

--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@
 
 m4_define([mate_utils_major], [1])
 m4_define([mate_utils_minor], [28])
-m4_define([mate_utils_micro], [0])
+m4_define([mate_utils_micro], [1])
 
 m4_define([mate_utils_version], [mate_utils_major.mate_utils_minor.mate_utils_micro])
 


### PR DESCRIPTION
once this is merged I will create the tag with `git tag -a "v1.28.1" -m "Release 1.28.1"` which runs the ci pipeline for releases as described in https://mbkma.github.io/mate-desktop.org/docs/member/releasing/