### PR TITLE
baobab: Fix no size sorting for remote locations (#383)

### DIFF
--- a/baobab/src/baobab.c
+++ b/baobab/src/baobab.c
@@ -234,6 +234,8 @@ baobab_scan_location (GFile *file)
 		gtk_toggle_action_set_active (ck_allocated, FALSE);
 		gtk_action_set_sensitive (GTK_ACTION (ck_allocated), FALSE);
 		baobab.show_allocated = FALSE;
+
+		baobab_treeview_show_allocated_size (baobab.tree_view, FALSE);
 	}
 	else {
 		gtk_action_set_sensitive (GTK_ACTION (ck_allocated), TRUE);


### PR DESCRIPTION
Showing the allocated size is enabled by default, but will be disabled when a remote location is scanned. Hence also update the affected column in such case.

Fixes #383.